### PR TITLE
Fixed misleading message when user tried to process empty directory

### DIFF
--- a/kcc/KCC_gui.py
+++ b/kcc/KCC_gui.py
@@ -136,6 +136,10 @@ class WorkerThread(QtCore.QThread):
             try:
                 outputPath = comic2ebook.main(jobargv, self)
                 self.emit(QtCore.SIGNAL("hideProgressBar"))
+            except UserWarning as warn:
+                self.errors = True
+                self.emit(QtCore.SIGNAL("addMessage"), 'KCC failed to create output file!', 'warning')
+                self.emit(QtCore.SIGNAL("addMessage"), str(warn), 'warning')
             except Exception as err:
                 self.errors = True
                 type_, value_, traceback_ = sys.exc_info()

--- a/kcc/comic2ebook.py
+++ b/kcc/comic2ebook.py
@@ -340,7 +340,7 @@ def applyImgOptimization(img, isSplit, toRight, options, overrideQuality=5):
         img.quantizeImage()
 
 
-def dirImgProcess(path):
+def dirImgProcess(path, origPath):
     global options, splitCount
     work = []
     pagenumber = 0
@@ -379,6 +379,9 @@ def dirImgProcess(path):
                 splitCount += 1
                 pagenumbermodifier += 1
             pagenumbermodifier += 1
+    else:
+        rmtree(path)
+        raise UserWarning("Empty directory: " + origPath)
 
 
 def fileImgProcess_init(queue, options):
@@ -739,7 +742,7 @@ def main(argv=None, qtGUI=None):
         print "Processing images..."
         if GUI:
             GUI.emit(QtCore.SIGNAL("progressBarTick"), 'status', 'Processing images')
-        dirImgProcess(path + "/OEBPS/Images/")
+        dirImgProcess(path + "/OEBPS/Images/", args[0])
     if GUI:
         GUI.emit(QtCore.SIGNAL("progressBarTick"), 1)
     if options.cbzoutput:


### PR DESCRIPTION
There was no exception raised when no pages where found in work directory so empty epub/cbz file was created, but kindlegen failed when processing it resulting in "batch size" message. Added UserWarning for such situation.
