### PR TITLE
Set first image in folder as cover

### DIFF
--- a/kcc/comic2ebook.py
+++ b/kcc/comic2ebook.py
@@ -424,6 +424,7 @@ def buildEPUB(path, chapterNames, tomeNumber):
     f.close()
     for (dirpath, dirnames, filenames) in walk(os.path.join(path, 'OEBPS', 'Images')):
         chapter = False
+        filenames.sort()
         for afile in filenames:
             filename = getImageFileName(afile)
             if '-kcc-hq' not in filename[0]:


### PR DESCRIPTION
The walk() function does not necessarily return filenames in
alphabetical order. This leads to a random cover image.

Sorting filenames before setting the cover images fixes this issue.

Fixes #127 