### PR TITLE
Fix for combo box issue on retina display

### DIFF
--- a/gui/KCC-OSX.ui
+++ b/gui/KCC-OSX.ui
@@ -182,10 +182,10 @@
    <widget class="QComboBox" name="DeviceBox">
     <property name="geometry">
      <rect>
-      <x>8</x>
-      <y>201</y>
+      <x>10</x>
+      <y>210</y>
       <width>151</width>
-      <height>34</height>
+      <height>21</height>
      </rect>
     </property>
     <property name="font">
@@ -205,9 +205,9 @@
     <property name="geometry">
      <rect>
       <x>262</x>
-      <y>201</y>
+      <y>210</y>
       <width>152</width>
-      <height>34</height>
+      <height>21</height>
      </rect>
     </property>
     <property name="font">


### PR DESCRIPTION
This should fix the issue, the combobox is now set to the default height. Not sure exactly how to compile this into an OSX binary to test it fully.