### PR TITLE
Allow for multiple file arguments on startup

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -815,7 +815,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             formats = ['.cbz', '.zip', '.pdf']
             if self.UnRAR:
                 formats.extend(['.cbr', '.rar'])
-                if self.sevenza:
+            if self.sevenza:
                 formats.extend(['.cb7', '.7z'])
             if os.path.isdir(message):
                 GUI.jobList.addItem(message)
@@ -826,7 +826,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                     GUI.jobList.addItem(message)
                     GUI.jobList.scrollToBottom()
                 else:
-                    self.addMessage('This file type is unsupported!', 'error')
+                    self.addMessage('Unsupported file type for ' + message, 'error')
 
     def dragAndDrop(self, e):
         e.accept()

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -812,16 +812,11 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             if self.needClean:
                 self.needClean = False
                 GUI.jobList.clear()
+            formats = ['.cbz', '.zip', '.pdf']
             if self.UnRAR:
+                formats.extend(['.cbr', '.rar'])
                 if self.sevenza:
-                    formats = ['.cbz', '.cbr', '.cb7', '.zip', '.rar', '.7z', '.pdf']
-                else:
-                    formats = ['.cbz', '.cbr', '.zip', '.rar', '.pdf']
-            else:
-                if self.sevenza:
-                    formats = ['.cbz', '.cb7', '.zip', '.7z', '.pdf']
-                else:
-                    formats = ['.cbz', '.zip', '.pdf']
+                formats.extend(['.cb7', '.7z'])
             if os.path.isdir(message):
                 GUI.jobList.addItem(message)
                 GUI.jobList.scrollToBottom()

--- a/kindlecomicconverter/startup.py
+++ b/kindlecomicconverter/startup.py
@@ -30,15 +30,15 @@ def start():
     os.environ['QT_AUTO_SCREEN_SCALE_FACTOR'] = "1"
     KCCAplication = KCC_gui.QApplicationMessaging(sys.argv)
     if KCCAplication.isRunning():
-        if len(sys.argv) > 1:
-            KCCAplication.sendMessage(sys.argv[1])
+        for i in range (1, len(sys.argv)):
+            KCCAplication.sendMessage(sys.argv[i])
         else:
             KCCAplication.sendMessage('ARISE')
     else:
         KCCWindow = KCC_gui.QMainWindowKCC()
         KCCUI = KCC_gui.KCCGUI(KCCAplication, KCCWindow)
-        if len(sys.argv) > 1:
-            KCCUI.handleMessage(sys.argv[1])
+        for i in range (1, len(sys.argv)):
+            KCCUI.handleMessage(sys.argv[i])
         sys.exit(KCCAplication.exec_())
 
 


### PR DESCRIPTION
This allows for multiple files to be loaded when opening kcc from the terminal with arguments and makes the file type validation and error more streamlined and informative.