### PR TITLE
Fix No Files Bug

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -61,7 +61,10 @@ def main(argv=None):
         parser.print_help()
         return 0
     if sys.platform.startswith('win'):
-        sources = set([source for arg in args for source in glob(arg)])
+        sources = []
+        for arg in args:
+            if os.path.exists(arg):
+                sources.append(arg)
     else:
         sources = set(args)
     if len(sources) == 0:


### PR DESCRIPTION
Change *glob()*  to *os.path.exists()*, to fix the "No matching files found" probem when the filename contains "[]".

For example, there is a comic:
*'[河本ほむら×尚村透] 賭ケグルイ 第10巻.zip'*

Because filename contains *[ ]*, so glob will not get the file correct.