### PR TITLE
Clarify Pillow version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ pip install --user KindleComicConverter
 ## DEPENDENCIES
 Following software is required to run Linux version of **KCC** and/or bare sources:
 - Python 3.3+
-- [PyQt5](https://pypi.python.org/pypi/PyQt5) 5.6.0+
-- [Pillow](https://pypi.python.org/pypi/Pillow/) 4.0.0+
+- [PyQt5](https://pypi.python.org/pypi/PyQt5) 5.6.0+ (only needed for GUI)
+- [Pillow](https://pypi.python.org/pypi/Pillow/) 4.0.0+ (5.2.0+ needed for WebP support)
 - [psutil](https://pypi.python.org/pypi/psutil) 5.0.0+
 - [python-slugify](https://pypi.python.org/pypi/python-slugify) 1.2.1+, <3.0.0
-- [raven](https://pypi.python.org/pypi/raven) 6.0.0+
+- [raven](https://pypi.python.org/pypi/raven) 6.0.0+ (only needed for GUI)
 
 On Debian based distributions these two commands should install all needed dependencies:
 ```


### PR DESCRIPTION
  * Pillow version requirement in code is 5.2.0+ since support for WebP was added for issue #240 
  * Clarify optional GUI dependencies, kcc-c2p.py/kcc-c2e.py does not need pyqt nor raven.