### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ $ pip3 install --user --upgrade pillow python-slugify psutil pyqt5 raven
 ```
 
 #### Optional dependencies
+- Qt platform integration plugin for Deepin Desktop Environment
+```bash
+$ sudo apt-get install qt5dxcb-plugin
+```
+
 - KindleGen ~~[deprecated link](http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211)~~ v2.9+ in a directory reachable by your _PATH_ or in _KCC_ directory *(For MOBI generation)
  – which offers a command line interface and supports [Linux](https://archive.org/details/kindlegen2.9) [(mirror1)](https://archive.org/download/kindlegen_linux_2_6_i386_v2_9/kindlegen_linux_2.6_i386_v2_9.tar.gz), [Mac OSX](https://web.archive.org/web/20190905040839/https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211) and [Windows](https://archive.org/details/kindlegen_win32_v2_9) – has been deprecated, but binaries can still be found on the internet.
 - [7z](http://www.7-zip.org/download.html) *(For CBZ/ZIP, CBR/RAR, 7z/CB7 support)*


### PR DESCRIPTION
Dependency qt5dxcb-plugin required for KCC added. The kindlegen tool is no longer available through amazon, the link was replaced by a link to archive.org.