### PR TITLE
use copyfile and delete instead of shutil.move fix #386

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -27,7 +27,7 @@ from re import sub
 from stat import S_IWRITE, S_IREAD, S_IEXEC
 from zipfile import ZipFile, ZIP_STORED, ZIP_DEFLATED
 from tempfile import mkdtemp, gettempdir, TemporaryFile
-from shutil import move, copytree, rmtree
+from shutil import move, copytree, rmtree, copyfile
 from optparse import OptionParser, OptionGroup
 from multiprocessing import Pool
 from uuid import uuid4
@@ -1130,7 +1130,12 @@ def makeBook(source, qtgui=None):
             else:
                 filepath.append(getOutputFilename(source, options.output, '.epub', ''))
             makeZIP(tome + '_comic', tome, True)
-        move(tome + '_comic.zip', filepath[-1])
+        copyfile(tome + '_comic.zip', filepath[-1])
+        try:
+            os.remove(tome + '_comic.zip')
+        except FileNotFoundError:
+            # newly temporary created file is not found. It might have been already deleted
+            pass
         rmtree(tome, True)
         if GUI:
             GUI.progressBarTick.emit('tick')


### PR DESCRIPTION
Convert process ERROR when using SMB/CIFS : Operation not permitted / link Invalid cross-device link

At the end of convert process, the created file is moved from temp folder to same folder as original file with shutil.move
shutil.move try to change stat (timestamp and file permissions) of the moved file
but like cp/mv shutil.move raise error "Operation not permitted" when copying to a cifs mount
shutil.copy have the same problem when trying to set file permissions. 

**SOLUTION**
use shutil.copyfile then os.remove
shutil.copyfile do not try to preserve timestamp and file permissions
This fix #386

**NOTE**
Here copy stat is not really usefull : it just copy timestamp of the newly created file in temp folder to put the same on the target to correct at best a few seconds
Despîte the fact it is a well known related SMB/CIFS problem which occurs when a user is declared at the mount point (usually root) and another user (any possible regular user on the system) is used to move the file
I think we might use this solution to move the file without modify stats because it cause too much problem for few seconds in timestamp.


**TRACE :**
```

abc@64c108309c49:~/tmp$ TMPDIR=/config/tmp kcc-c2e -f CBZ -p KoAHD /download/\[STAGING\]/\[MAGAZINES\]/amiganews/amiganews_numero02.zip
comic2ebook v5.5.2 - Written by Ciro Mattia Gonano and Pawel Jastrzebski.
Preparing source images...
Checking images...
Processing images...
Creating CBZ file...
Traceback (most recent call last):
  File "/usr/lib/python3.6/shutil.py", line 550, in move
    os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/config/tmp/KCC-q503brdf_comic.zip' -> '/download/[STAGING]/[MAGAZINES]/amiganews/amiganews_numero02_kcc0.cbz'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/kcc-c2e", line 8, in <module>
    sys.exit(startC2E())
  File "/usr/local/lib/python3.6/dist-packages/kindlecomicconverter/startup.py", line 49, in startC2E
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/lib/python3.6/dist-packages/kindlecomicconverter/comic2ebook.py", line 74, in main
    makeBook(source)
  File "/usr/local/lib/python3.6/dist-packages/kindlecomicconverter/comic2ebook.py", line 1133, in makeBook
    move(tome + '_comic.zip', filepath[-1])
  File "/usr/lib/python3.6/shutil.py", line 564, in move
    copy_function(src, real_dst)
  File "/usr/lib/python3.6/shutil.py", line 264, in copy2
    copystat(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.6/shutil.py", line 205, in copystat
    follow_symlinks=follow)
PermissionError: [Errno 1] Operation not permitted


```

**SAMPLE UNIX MOVE TEST :**
```

abc@64c108309c49:~/tmp$ cd /config/tmp
abc@64c108309c49:~/tmp$ ls
KCC-q503brdf  KCC-q503brdf_comic.zip
abc@64c108309c49:~/tmp$ mv KCC-q503brdf_comic.zip /download/
mv: preserving times for '/download/KCC-q503brdf_comic.zip': Operation not permitted
mv: preserving permissions for ‘/download/KCC-q503brdf_comic.zip’: Operation not permitted

```

**STRACE when trying to change timestamp :** 
```

openat(AT_FDCWD, "/download/[STAGING]/[MAGAZINES]/amiganews/amiganews_numero02_kcc1.cbz", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 16
stat("/tmp/KCC-4d2vgr_k_comic.zip", {st_mode=S_IFREG|0644, st_size=15441468, ...}) = 0
utimensat(AT_FDCWD, "/download/[STAGING]/[MAGAZINES]/amiganews/amiganews_numero02_kcc1.cbz", [{tv_sec=1613912351, tv_nsec=941703083} /* 2021-02-21T12:59:11.941703083+0000 */, {tv_sec=1613912351, tv_nsec=937703093} /* 2021-02-21T12:59:11.937703093+0000 */], 0) = -1 EPERM (Operation not permitted)
Traceback (most recent call last):
  File "/usr/lib/python3.6/shutil.py", line 550, in move
openat(AT_FDCWD, "/usr/lib/python3.6/shutil.py", O_RDONLY|O_CLOEXEC) = 15
    os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/tmp/KCC-4d2vgr_k_comic.zip' -> '/download/[STAGING]/[MAGAZINES]/amiganews/amiganews_numero02_kcc1.cbz'

```





