### PR TITLE
Fixed the skipped/missed images and/or panels

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1078,10 +1078,7 @@ def makeBook(source, qtgui=None):
     getComicInfo(os.path.join(path, "OEBPS", "Images"), source)
     detectCorruption(os.path.join(path, "OEBPS", "Images"), source)
     if options.webtoon:
-        if image.ProfileData.Profiles[options.profile][1][1] > 1024:
-            y = 1024
-        else:
-            y = image.ProfileData.Profiles[options.profile][1][1]
+        y = image.ProfileData.Profiles[options.profile][1][1]
         comic2panel.main(['-y ' + str(y), '-i', '-m', path], qtgui)
     print("Processing images...")
     if GUI:
@@ -1222,7 +1219,7 @@ def makeMOBI(work, qtgui=None):
         threadNumber = 1
     elif 2 < availableMemory <= 4:
         threadNumber = 2
-    elif 4 < availableMemory <= 8:
+    elif 4 < availableMemory:
         threadNumber = 4
     else:
         threadNumber = None


### PR DESCRIPTION
This pull request consists of several fixes:

**mergeDirectory()**
**Problem:** If the image width is greater than the targetWidth, app skips that image and omits from converting it. 
**Solution:** if that happens the code resizes the image to the targetWidth while preserving the aspect ratio.

**splitImage()**
**Problem:** If the panel at the bottom of the image is not followed by a solid cropped row then the app doesn't add that panel to the panels array. 
**Solution:** If last the panel is detected but there is no solid cropped row at the bottom of the image, code sets the panel bottom dimension to the heightImg.

**Problem:** If the source image is badly cropped and has a thin black outline it causes app to consider whole image as one panel which ends up with lots of unnecessary empty pages, or tiny panels.
**Solution:** 4 pixels from right and left gets cropped by default to avoid that, It's thin enough to not cause a major problem with the actual image but eliminates the problem with some of the outlines.

**Problem:** Larger sized images (as far as I can see images larger than 1.5-2mb) throws a "DecompressionBombWarning". 
**Solution:** I set the MAX_IMAGE_PIXELS = 1000000000 and put a simple warning.

**makeBook()**
**Problem:** Max height is set to 1024 by default. So, even your device resolution is higher than that images are cropped by 1024. This causes some images that might actually fit to the screen to be cropped to two. 
**Solution:** Max height is now set to device's resolution. (For example for Kindle PW 3+ it's 1448 now.)

I also implemented @pavelzw pull request [for systems with with a lot of RAM](https://github.com/ciromattia/kcc/pull/376)
