### PR TITLE
sync python requirements between setup.py and requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
         'PyQt5>=5.6.0',
         'Pillow>=5.2.0',
         'psutil>=5.0.0',
-        'python-slugify>=1.2.1',
+        'python-slugify>=1.2.1,<3.0.0',
         'raven>=6.0.0',
     ],
     classifiers=[],


### PR DESCRIPTION

sync python requirements between setup.py and requirements.txt

this avoid installation problem when install from
pip install git+http://

this avoid also problems like these : https://github.com/ciromattia/kcc/issues/410