### PR TITLE
Fix program to work with new dependency versions

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -255,7 +255,7 @@ class ComicPage:
         if gamma == 1.0:
             self.image = ImageOps.autocontrast(self.image)
         else:
-            self.image = ImageOps.autocontrast(Image.eval(self.image, lambda a: 255 * (a / 255.) ** gamma))
+            self.image = ImageOps.autocontrast(Image.eval(self.image, lambda a: int(255 * (a / 255.) ** gamma)))
 
     def quantizeImage(self):
         colors = len(self.palette) // 3

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -118,6 +118,8 @@ def dependencyCheck(level):
             missing.append('psutil 5.0.0+')
         try:
             from slugify import __version__ as slugifyVersion
+            if not isinstance(slugifyVersion, str):
+                slugifyVersion = slugifyVersion.__version__
             if StrictVersion('1.2.1') > StrictVersion(slugifyVersion):
                 missing.append('python-slugify 1.2.1+')
         except ImportError:

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -117,8 +117,9 @@ def dependencyCheck(level):
         except ImportError:
             missing.append('psutil 5.0.0+')
         try:
+            from types import ModuleType
             from slugify import __version__ as slugifyVersion
-            if not isinstance(slugifyVersion, str):
+            if isinstance(slugifyVersion, ModuleType):
                 slugifyVersion = slugifyVersion.__version__
             if StrictVersion('1.2.1') > StrictVersion(slugifyVersion):
                 missing.append('python-slugify 1.2.1+')


### PR DESCRIPTION
The script was crashing in two places due to changes in behaviour of two dependecies (pillow and slugify).
The crash concerning `slugify` was caused by a moved `__version__` variable, which in turn caused the script to fail during dependency checks.
The crash in PIL was due to a lambda that did not round the returned value to int, thus causing PIL to raise an exception (TypeError float object cannot be interpreted as an integer).