### PR TITLE
Fix version range used for `slugify` by python "pip" based installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
         'PyQt5>=5.6.0',
         'Pillow>=5.2.0',
         'psutil>=5.0.0',
-        'python-slugify>=1.2.1',
+        'python-slugify>=1.2.1,<3.0.0',
         'raven>=6.0.0',
     ],
     classifiers=[],


### PR DESCRIPTION
Should fix #444

There were two possibilities here:

1. Fixing the version detection
2. Fixing the version range being used in the setup phase

While the former one could be sufficient to "hide the bug" it wouldn't actually be preventing from using an unsupported version, so I went for the 2nd option here.
