### PR TITLE
Add default behavior when panels not found

### DIFF
--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -124,6 +124,9 @@ def splitImage(work):
                     panels.append((panelY1, panelY2, panelY2 - panelY1))
                 yWork += 5
 
+            if len(panels) == 0:
+                panels.append((panelY1, heightImg, heightImg - panelY1))
+
             # Split too big panels
             panelsProcessed = []
             for panel in panels:


### PR DESCRIPTION
There are some cases that we cannot find the panels and are not returning anything.

So this PR is for adding the whole page and it will be split instead of return nothing