### PR TITLE
Fix pillow backwards compatibility, add mozjpeg-lossless-optimization to setup.py

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -115,10 +115,10 @@ class ComicPageParser:
         self.image = Image.open(os.path.join(source[0], source[1])).convert('RGB')
         self.color = self.colorCheck()
         self.fill = self.fillCheck()
-        self.splitCheck()
         # backwards compatibility for Pillow >9.1.0
         if not hasattr(Image, 'Resampling'):
             Image.Resampling = Image
+        self.splitCheck()
 
     def getImageHistogram(self, image):
         histogram = image.histogram()
@@ -381,10 +381,10 @@ class Cover:
         else:
             self.tomeid = tomeid
         self.image = Image.open(source)
-        self.process()
         # backwards compatibility for Pillow >9.1.0
         if not hasattr(Image, 'Resampling'):
             Image.Resampling = Image
+        self.process()
 
     def process(self):
         self.image = self.image.convert('RGB')

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setuptools.setup(
         'psutil>=5.0.0',
         'python-slugify>=1.2.1,<8.0.0',
         'raven>=6.0.0',
+        'mozjpeg-lossless-optimization>=1.1.2',
     ],
     classifiers=[],
     zip_safe=False,


### PR DESCRIPTION
- Fix pillow backwards compatibility - sequence of monkey patch is incorrect
- Add mozjpeg-lossless-optimization to setup.py - supporting installation from github via pip