### PR TITLE
Crop to fill screen

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -310,8 +310,9 @@ class ComicPage:
         else:
             method = Image.Resampling.LANCZOS
         if self.opt.stretch:
+            self.image = ImageOps.fit(self.image, self.size, method)
         # if self.opt.stretch or (self.opt.kfx and ('-KCC-B' in self.targetPath or '-KCC-C' in self.targetPath)):
-            self.image = self.image.resize(self.size, method)
+            # self.image = self.image.resize(self.size, method)
         elif self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1] and not self.opt.upscale:
             if self.opt.format == 'CBZ' or self.opt.kfx:
                 borderw = int((self.size[0] - self.image.size[0]) / 2)


### PR DESCRIPTION
Use ImageOps.fit instead of image.resize

Want to discuss with the team on how to integrate this feature. The barebones implementation is just replacing the stretch to fit feature with a crop to fill screen feature, not sure if team is OK with that. But I don't think people want to change the aspect ratio of their manga.

Solve #391

Example of using cropping feature. Notice the cropped out steam from the Titan and slightly cropped shirt of Eren.

![image](https://user-images.githubusercontent.com/20757319/214721133-d93b0090-1e1c-4d24-842b-c848eb1fb372.png)

For now, I'm running kcc locally to do what I want, thanks!


