### PR TITLE
Updates GUI text for new Homebrew version

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -899,8 +899,9 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                 if sys.platform.startswith('win'):
                     self.addMessage('Download it and place EXE in KCC directory.', 'error')
                 elif sys.platform.startswith('darwin'):
-                    self.addMessage('Install it using <a href="http://brew.sh/">Homebrew</a>: <i>brew install --cask kindle-c'
-                                    'omic-creator</i>', 'error')
+                    self.addMessage('Install it using <a href="http://brew.sh/">Homebrew</a>: '
+                                    '<i>brew install --cask kindle-comic-creator</i> or '
+                                    '<i>brew install --cask kindle-previewer</i>', 'error')
                 else:
                     self.addMessage('Download it and place executable in /usr/local/bin directory.', 'error')
 

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -788,7 +788,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                     if sys.platform.startswith('win'):
                         self.addMessage('Download it and place EXE in KCC directory.', 'error')
                     elif sys.platform.startswith('darwin'):
-                        self.addMessage('Install it using <a href="http://brew.sh/">Brew</a>.', 'error')
+                        self.addMessage('Install it using <a href="http://brew.sh/">Homebrew</a>.', 'error')
                     else:
                         self.addMessage('Download it and place executable in /usr/local/bin directory.', 'error')
                     self.needClean = True
@@ -899,7 +899,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                 if sys.platform.startswith('win'):
                     self.addMessage('Download it and place EXE in KCC directory.', 'error')
                 elif sys.platform.startswith('darwin'):
-                    self.addMessage('Install it using <a href="http://brew.sh/">Brew</a>: <i>brew cask install kindle-c'
+                    self.addMessage('Install it using <a href="http://brew.sh/">Homebrew</a>: <i>brew install --cask kindle-c'
                                     'omic-creator</i>', 'error')
                 else:
                     self.addMessage('Download it and place executable in /usr/local/bin directory.', 'error')


### PR DESCRIPTION
The instructions in the GUI for downloading the kindle-comic-creator cask utilize an old brew command, so this PR updates the GUI text with the command that Homebrew uses now. It also renames references to "Brew" to "Homebrew".

![Screenshot of the GUI with the old command](https://user-images.githubusercontent.com/18013689/224471684-1657daf3-d1c2-46c3-a1f1-88b2ea9bf54c.png)

---

This is what current homebrew tells you if you use the old command that the GUI suggests:
```shell
jameskerrane@Jamess-MBP ~> brew cask install kindle-comic-creator
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

This is a successful installation with the command that I changed the GUI instructions to:

```shell
jameskerrane@Jamess-MBP ~ [1]> brew install --cask kindle-comic-creator
==> Downloading https://kc2.s3.amazonaws.com/KindleComicCreatorInstall.dmg
Already downloaded: /Users/jameskerrane/Library/Caches/Homebrew/downloads/29bff483a8f694859b20eacf3cd654d0565c07fc31165f9ba8408c3f88edb26a--KindleComicCreatorInstall.dmg
Warning: No checksum defined for cask 'kindle-comic-creator', skipping verification.
==> Installing Cask kindle-comic-creator
==> Running installer for kindle-comic-creator; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
Password:
installer: Package name is Kindle Comic Creator
installer: Installing at base path /
installer: The install was successful.
🍺  kindle-comic-creator was successfully installed!
```
