### PR TITLE
remove transparency from image info

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -265,6 +265,7 @@ class ComicPage:
             if self.fill != 'white':
                 flags.append('BlackBackground')
             if self.opt.forcepng:
+                self.image.info["transparency"] = None
                 self.targetPath += '.png'
                 self.image.save(self.targetPath, 'PNG', optimize=1)
             else:


### PR DESCRIPTION
kcc will crash if source image has transparency and saving to png. 

Was not a problem in mangle due to Python 2/3 differences. https://github.com/python-pillow/Pillow/issues/3150#issuecomment-401577626

Here's a source image that causes crashes.

![Liar_Game-v01_055](https://user-images.githubusercontent.com/20757319/227733193-3b1c7424-ed91-426d-a158-13239fb41eb2.png)
