### PR TITLE
Crop images within 3% of device aspect ratio

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -324,7 +324,7 @@ class ComicPage:
                 borderh = int((self.size[1] - self.image.size[1]) / 2)
                 self.image = ImageOps.expand(self.image, border=(borderw, borderh), fill=self.fill)
                 if self.image.size[0] != self.size[0] or self.image.size[1] != self.size[1]:
-                    self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
+                    self.image = ImageOps.fit(self.image, self.size, method=method)
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
                 self.image = ImageOps.fit(self.image, self.size, method=method)

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -326,16 +326,12 @@ class ComicPage:
                 if self.image.size[0] != self.size[0] or self.image.size[1] != self.size[1]:
                     self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
         else: # if image bigger than device resolution or smaller with upscaling
-            if self.opt.format == 'CBZ' or self.opt.kfx:
-                if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
-                    self.image = ImageOps.fit(self.image, self.size, method=method)
-                else:    
-                    self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
+            if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
+                self.image = ImageOps.fit(self.image, self.size, method=method)
+            elif self.opt.format == 'CBZ' or self.opt.kfx:
+                self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
             else:
-                if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
-                    self.image = ImageOps.fit(self.image, self.size, method=method)
-                else:
-                    self.image = ImageOps.contain(self.image, self.size, method=method)
+                self.image = ImageOps.contain(self.image, self.size, method=method)
 
     def resize_method(self):
         if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -24,6 +24,13 @@ import mozjpeg_lossless_optimization
 from PIL import Image, ImageOps, ImageStat, ImageChops, ImageFilter
 from .shared import md5Checksum
 
+# 0.045 was determined by
+# 1200 / 824 = 1.456 (Kindle DX resolution)
+# 2250 / 1500 = 1.5 (Typical manga page resolution)
+# 1.5 - 1.456 < 0.045
+# 0.045 / 1.5 = 0.03 (So maximum 3% of is cropped)
+AUTO_CROP_THRESHOLD = 0.045
+
 
 class ProfileData:
     def __init__(self):
@@ -306,36 +313,42 @@ class ComicPage:
         self.image = self.image.quantize(palette=palImg)
 
     def resizeImage(self):
-        if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:
-            method = Image.Resampling.BICUBIC
-        else:
-            method = Image.Resampling.LANCZOS
+
+        ratio_device = float(self.size[0]) / float(self.size[1])
+        ratio_image = float(self.image.size[0]) / float(self.image.size[1])
+        method = self.resize_method()
         if self.opt.stretch:
-        # if self.opt.stretch or (self.opt.kfx and ('-KCC-B' in self.targetPath or '-KCC-C' in self.targetPath)):
             self.image = self.image.resize(self.size, method)
-        elif self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1] and not self.opt.upscale:
+        elif method == Image.Resampling.BICUBIC and not self.opt.upscale:
             if self.opt.format == 'CBZ' or self.opt.kfx:
                 borderw = int((self.size[0] - self.image.size[0]) / 2)
                 borderh = int((self.size[1] - self.image.size[1]) / 2)
                 self.image = ImageOps.expand(self.image, border=(borderw, borderh), fill=self.fill)
                 if self.image.size[0] != self.size[0] or self.image.size[1] != self.size[1]:
-                    self.image = ImageOps.fit(self.image, self.size, method=Image.Resampling.BICUBIC, centering=(0.5, 0.5))
-        else:
+                    self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
+        else: # if image bigger than device resolution or smaller with upscaling
             if self.opt.format == 'CBZ' or self.opt.kfx:
-                ratioDev = float(self.size[0]) / float(self.size[1])
-                if (float(self.image.size[0]) / float(self.image.size[1])) < ratioDev:
-                    diff = int(self.image.size[1] * ratioDev) - self.image.size[0]
+                if ratio_image < ratio_device:
+                    diff = int(self.image.size[1] * ratio_device) - self.image.size[0]
                     self.image = ImageOps.expand(self.image, border=(int(diff / 2), 0), fill=self.fill)
-                elif (float(self.image.size[0]) / float(self.image.size[1])) > ratioDev:
-                    diff = int(self.image.size[0] / ratioDev) - self.image.size[1]
+                elif ratio_image > ratio_device:
+                    diff = int(self.image.size[0] / ratio_device) - self.image.size[1]
                     self.image = ImageOps.expand(self.image, border=(0, int(diff / 2)), fill=self.fill)
                 self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
             else:
-                hpercent = self.size[1] / float(self.image.size[1])
-                wsize = int((float(self.image.size[0]) * float(hpercent)))
-                self.image = self.image.resize((wsize, self.size[1]), method)
+                if abs(1 / ratio_image - 1 / ratio_device) < AUTO_CROP_THRESHOLD:
+                    self.image = ImageOps.fit(self.image, self.size, method=method)
+                else:
+                    self.image = ImageOps.contain(self.image, self.size, method=method)
                 if self.image.size[0] > self.size[0] or self.image.size[1] > self.size[1]:
                     self.image.thumbnail(self.size, Image.Resampling.LANCZOS)
+
+    def resize_method(self):
+        if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:
+            method = Image.Resampling.BICUBIC
+        else:
+            method = Image.Resampling.LANCZOS
+        return method
 
     def getBoundingBox(self, tmptmg):
         min_margin = [int(0.005 * i + 0.5) for i in tmptmg.size]

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -313,35 +313,22 @@ class ComicPage:
         self.image = self.image.quantize(palette=palImg)
 
     def resizeImage(self):
-
-        ratio_device = float(self.size[0]) / float(self.size[1])
-        ratio_image = float(self.image.size[0]) / float(self.image.size[1])
+        ratio_device = float(self.size[1]) / float(self.size[0])
+        ratio_image = float(self.image.size[1]) / float(self.image.size[0])
         method = self.resize_method()
         if self.opt.stretch:
             self.image = self.image.resize(self.size, method)
         elif method == Image.Resampling.BICUBIC and not self.opt.upscale:
             if self.opt.format == 'CBZ' or self.opt.kfx:
-                borderw = int((self.size[0] - self.image.size[0]) / 2)
-                borderh = int((self.size[1] - self.image.size[1]) / 2)
-                self.image = ImageOps.expand(self.image, border=(borderw, borderh), fill=self.fill)
-                if self.image.size[0] != self.size[0] or self.image.size[1] != self.size[1]:
-                    self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
+                self.image = ImageOps.pad(self.image, self.size, method, self.fill) 
         else: # if image bigger than device resolution or smaller with upscaling
             if self.opt.format == 'CBZ' or self.opt.kfx:
-                if ratio_image < ratio_device:
-                    diff = int(self.image.size[1] * ratio_device) - self.image.size[0]
-                    self.image = ImageOps.expand(self.image, border=(int(diff / 2), 0), fill=self.fill)
-                elif ratio_image > ratio_device:
-                    diff = int(self.image.size[0] / ratio_device) - self.image.size[1]
-                    self.image = ImageOps.expand(self.image, border=(0, int(diff / 2)), fill=self.fill)
-                self.image = ImageOps.fit(self.image, self.size, method=method, centering=(0.5, 0.5))
+                self.image = ImageOps.pad(self.image, self.size, method, self.fill)
             else:
-                if abs(1 / ratio_image - 1 / ratio_device) < AUTO_CROP_THRESHOLD:
+                if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
                     self.image = ImageOps.fit(self.image, self.size, method=method)
                 else:
                     self.image = ImageOps.contain(self.image, self.size, method=method)
-                if self.image.size[0] > self.size[0] or self.image.size[1] > self.size[1]:
-                    self.image.thumbnail(self.size, Image.Resampling.LANCZOS)
 
     def resize_method(self):
         if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:


### PR DESCRIPTION
Because filling the screen with double page spreads looks amazing on the new Kindle Scribe with its 4:3 aspect ratio. (even though the images are downscaled to 1920x1440 per #460)

Also, replaces previous code that could potentially resize images twice, leading to quality loss, instead just using library functions to do it in one pass.

This also demonstrates the maximum crop visually. **But the real problem is when the edge is only a few pixels wide**  

dx EXAMPLE:
![image](https://github.com/ciromattia/kcc/assets/20757319/9c4d679e-a346-4941-acdd-825e7d769c6b)


Before:
![336727031_161307839831193_5858764873860971013_n](https://user-images.githubusercontent.com/20757319/229384460-c504f594-cd2a-48cc-a172-17c5914b43d4.jpg)

After:
![336774277_108188085560727_7844498634616129301_n](https://user-images.githubusercontent.com/20757319/229384461-c1f984a4-916c-40c8-ad1b-e522c32481bf.jpg)

Here is what the maximum crop looks like:

![IMG_20230513_072645.jpg](https://github.com/ciromattia/kcc/assets/20757319/db87c26e-7833-4eb6-ae05-8193a305c5e4)

![IMG_20230513_072635.jpg](https://github.com/ciromattia/kcc/assets/20757319/6a6fb8b2-57e2-455e-a5e4-de726e7bf04e)

