### PR TITLE
dramatically increase Scribe quality/speed

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -87,7 +87,7 @@ class ProfileData:
         'KV': ("Kindle Paperwhite 3/4/Voyage/Oasis", (1072, 1448), Palette16, 1.8),
         'KPW5': ("Kindle Paperwhite 5/Signature Edition", (1236, 1648), Palette16, 1.8),
         'KO': ("Kindle Oasis 2/3", (1264, 1680), Palette16, 1.8),
-        'KS': ("Kindle Scribe", (1860, 2480), Palette16, 1.8),
+        'KS': ("Kindle Scribe", (1440, 1920), Palette16, 1.8),
         'KoMT': ("Kobo Mini/Touch", (600, 800), Palette16, 1.8),
         'KoG': ("Kobo Glo", (768, 1024), Palette16, 1.8),
         'KoGHD': ("Kobo Glo HD", (1072, 1448), Palette16, 1.8),


### PR DESCRIPTION
Until the issue with Kindlegen #460 is resolved, I suggest lowering the Scribe resolution to the max output of kindlegen

Kindlegen downscaling images makes images soft compared to letting KCC downscale it.

Also, kindlegen runs super slow when downscaling per #493. If KCC has already downscaled it to 1440x1920, it runs instantly. On my PC, it's the difference between 15 second and 6 minute processing.