### PR TITLE
Allow unrar to overwrite files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ On Debian based distributions these two commands should install all needed depen
 
 
 ```bash
-$ sudo apt-get install -y python3 python3-dev libpng-dev libjpeg-dev p7zip-full unrar-free libgl1 python3-pyqt5 && \
+$ sudo apt-get install -y python3 python3-dev libpng-dev libjpeg-dev p7zip-full p7zip-rar unrar-free libgl1 python3-pyqt5 && \
     python -m pip install --upgrade pip && \
     python -m pip install --upgrade -r requirements.txt
 ```

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -57,7 +57,7 @@ class ComicArchive:
                         self.filepath + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
         process.communicate()
         if process.returncode != 0:
-            process = Popen('unrar x -y -x__MACOSX -x.DS_Store -xthumbs.db -xThumbs.db "' + self.filepath + '" "' +
+            process = Popen('unrar x -y -o+ -x__MACOSX -x.DS_Store -xthumbs.db -xThumbs.db "' + self.filepath + '" "' +
                     targetdir + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
             process.communicate()
             if process.returncode != 0:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -57,7 +57,7 @@ class ComicArchive:
                         self.filepath + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
         process.communicate()
         if process.returncode != 0:
-            process = Popen('unrar x -y -o+ -x__MACOSX -x.DS_Store -xthumbs.db -xThumbs.db "' + self.filepath + '" "' +
+            process = Popen('unrar x -y -x__MACOSX -x.DS_Store -xthumbs.db -xThumbs.db "' + self.filepath + '" "' +
                     targetdir + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
             process.communicate()
             if process.returncode != 0:


### PR DESCRIPTION
On systems without the appropriate 7zip functionality, corrupt files will be created in the working directory, causing unrar to fail as its default behavior is to disallow overwriting files with the same names. Fixes #489 