### PR TITLE
add 7z to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ $ sudo apt-get install qt5dxcb-plugin
 - CB7, 7Z *(With `7z` executable)*
 - PDF *(Only extracting JPG images)*
 
+Add 7z to PATH via `setx path "%path%;C:\Program Files\7-Zip"`
+
 ## USAGE
 
 Should be pretty self-explanatory. All options have detailed information in tooltips.

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1076,7 +1076,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         else:
             self.sevenzip = False
             self.addMessage('Cannot find <a href="http://www.7-zip.org/download.html">7z</a>!'
-                            ' Processing of archives will be disabled.', 'warning')
+                            ' Processing of archives will be disabled. Add 7z to PATH.', 'warning')
         self.detectKindleGen(True)
 
         APP.messageFromOtherInstance.connect(self.handleMessage)

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1075,8 +1075,8 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.sevenzip = True
         else:
             self.sevenzip = False
-            self.addMessage('Cannot find <a href="http://www.7-zip.org/download.html">7z</a>!'
-                            ' Processing of archives will be disabled. Add 7z to PATH.', 'warning')
+            self.addMessage('Add <a href="http://www.7-zip.org/download.html">7z</a> to PATH!'
+                            ' Processing of archives will be disabled.', 'warning')
         self.detectKindleGen(True)
 
         APP.messageFromOtherInstance.connect(self.handleMessage)


### PR DESCRIPTION
@cookie99999 @saisot2006 would this fix 7z support on Windows? I notice that when running from source it finds 7z fine but not when running the `.exe` until added to PATH. 

EDIT: When running from source, it uses the 7z in the `other` folder in the repo, not from PATH.

Would prevent issues like #481

![image](https://github.com/ciromattia/kcc/assets/20757319/64043ef8-e251-467c-aa7d-7b4fe8f4430d)
