### PR TITLE
limit kindle scribe image size to (1440, 1920) when using kindlegen

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1153,7 +1153,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         self.versionCheck.start()
         self.tray.show()
 
-        # Cleanup unfisnished conversion
+        # Cleanup unfinished conversion
         for root, dirs, _ in walkLevel(gettempdir(), 0):
             for tempdir in dirs:
                 if tempdir.startswith('KCC-'):

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1092,6 +1092,10 @@ def checkOptions(options):
         image.ProfileData.Profiles["Custom"] = newProfile
         options.profile = "Custom"
     options.profileData = image.ProfileData.Profiles[options.profile]
+    # kindle scribe conversion to mobi is limited in resolution by kindlegen
+    if options.profile == 'KS' and options.format == 'MOBI':
+        options.profileData = list(options.profileData)
+        options.profileData[1] = (1440, 1920)
     return options
 
 
@@ -1147,7 +1151,7 @@ def makeBook(source, qtgui=None):
         y = image.ProfileData.Profiles[options.profile][1][1]
         comic2panel.main(['-y ' + str(y), '-i', '-m', path], qtgui)
     if options.noprocessing:
-        print("Do not process image, ignore any profil or processing option")
+        print("Do not process image, ignore any profile or processing option")
     else:
         print("Processing images...")
         if GUI:


### PR DESCRIPTION
limit kindle scribe image size to (1440, 1920) when using kindlegen

- see #500
- fix  #493
- see  #460