### PR TITLE
Addition of a conda environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: kcc
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - Pillow>=5.2.0
+  - psutil>=5.0.0
+  - python-slugify>=1.2.1
+  - raven>=6.0.0
+  - distro
+  - pip
+  - pip:
+    - mozjpeg-lossless-optimization>=1.1.2
+    - PyQt5>=5.6.0


### PR DESCRIPTION
As mentioned in #519.
This makes conda setup more effortless for us conda users.

There is a `pyqt` package on **conda-forge** but it was causing conflicts which can be troublesome at times.
I thought it best to stick to **pip** for `pyqt` to avoid conflict resolution.

Tested on **W10**.

Just as a reminder for anyone searching this, the command is
`conda env create -f environment.yml`