### PR TITLE
Bump conda python to 3.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
+  - python=3.11
   - Pillow>=5.2.0
   - psutil>=5.0.0
   - python-slugify>=1.2.1


### PR DESCRIPTION
Issue: #519 

This PR changes the default Python version when using Anaconda (conda) to 3.11.


This needs a thumbs-up from @darodi before merging.

