### PR TITLE
Override book's title if `Title` is set in XML

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -695,7 +695,9 @@ def getComicInfo(path, originalpath):
             os.remove(xmlPath)
             return
         options.authors = []
-        if defaultTitle:
+        if xml.data['Title']:
+            options.title = hescape(xml.data['Title'])
+        elif defaultTitle:
             if xml.data['Series']:
                 options.title = hescape(xml.data['Series'])
             if xml.data['Volume']:

--- a/kindlecomicconverter/metadata.py
+++ b/kindlecomicconverter/metadata.py
@@ -34,7 +34,8 @@ class MetadataParser:
                      'Inkers': [],
                      'Colorists': [],
                      'Summary': '',
-                     'Bookmarks': []}
+                     'Bookmarks': [],
+                     'Title': ''}
         self.rawdata = None
         self.format = None
         if self.source.endswith('.xml') and os.path.exists(self.source):
@@ -58,6 +59,8 @@ class MetadataParser:
             self.data['Number'] = self.rawdata.getElementsByTagName('Number')[0].firstChild.nodeValue
         if len(self.rawdata.getElementsByTagName('Summary')) != 0:
             self.data['Summary'] = self.rawdata.getElementsByTagName('Summary')[0].firstChild.nodeValue
+        if len(self.rawdata.getElementsByTagName('Title')) != 0:
+            self.data['Title'] = self.rawdata.getElementsByTagName('Title')[0].firstChild.nodeValue
         for field in ['Writer', 'Penciller', 'Inker', 'Colorist']:
             if len(self.rawdata.getElementsByTagName(field)) != 0:
                 for person in self.rawdata.getElementsByTagName(field)[0].firstChild.nodeValue.split(', '):
@@ -76,7 +79,8 @@ class MetadataParser:
             for row in (['Series', self.data['Series']], ['Volume', self.data['Volume']],
                         ['Number', self.data['Number']], ['Writer', ', '.join(self.data['Writers'])],
                         ['Penciller', ', '.join(self.data['Pencillers'])], ['Inker', ', '.join(self.data['Inkers'])],
-                        ['Colorist', ', '.join(self.data['Colorists'])], ['Summary', self.data['Summary']]):
+                        ['Colorist', ', '.join(self.data['Colorists'])], ['Summary', self.data['Summary']],
+                        ['Title', self.data['Title']]):
                 if self.rawdata.getElementsByTagName(row[0]):
                     node = self.rawdata.getElementsByTagName(row[0])[0]
                     if row[1]:
@@ -97,7 +101,8 @@ class MetadataParser:
             for row in (['Series', self.data['Series']], ['Volume', self.data['Volume']],
                         ['Number', self.data['Number']], ['Writer', ', '.join(self.data['Writers'])],
                         ['Penciller', ', '.join(self.data['Pencillers'])], ['Inker', ', '.join(self.data['Inkers'])],
-                        ['Colorist', ', '.join(self.data['Colorists'])], ['Summary', self.data['Summary']]):
+                        ['Colorist', ', '.join(self.data['Colorists'])], ['Summary', self.data['Summary']],
+                        ['Title', self.data['Title']]):
                 if row[1]:
                     main = doc.createElement(row[0])
                     root.appendChild(main)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Pillow>=5.2.0
 psutil>=5.0.0
 python-slugify>=1.2.1
 raven>=6.0.0
+pyinstaller>=5.11.0
 # PyQt5-tools
 mozjpeg-lossless-optimization>=1.1.2
 distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Pillow>=5.2.0
 psutil>=5.0.0
 python-slugify>=1.2.1
 raven>=6.0.0
-pyinstaller>=5.11.0
 # PyQt5-tools
 mozjpeg-lossless-optimization>=1.1.2
 distro


### PR DESCRIPTION
In ComicRack XML Schema, there is a `Title` field that is not being used by KCC. In this PR, I changed so that if this field is set, it will automatically be used.

Also, `pyinstaller` is added to `requirements.txt` for [building on M1](https://github.com/darodi/kcc/issues/4#issuecomment-1364553511) to avoid `pyinstaller: command not found`.