### PR TITLE
add 7z wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ $ sudo apt-get install qt5dxcb-plugin
 - CB7, 7Z *(With `7z` executable)*
 - PDF *(Only extracting JPG images)*
 
-Add 7z to PATH via `setx path "%path%;C:\Program Files\7-Zip"`
-
 ## USAGE
 
 Should be pretty self-explanatory. All options have detailed information in tooltips.

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1045,7 +1045,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.sevenzip = True
         else:
             self.sevenzip = False
-            self.addMessage('Install <a href="https://www.7-zip.org/">7-Zip</a> and add 7z to PATH!'
+            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation#7-zip">Install 7z and add to PATH!</a>!'
                             ' CBZ/CBR/ZIP/etc processing disabled.', 'warning')
         self.detectKindleGen(True)
 


### PR DESCRIPTION
How to add 7z to PATH was also way too common of a question on Reddit/GitHub/MobileRead, so added a wiki link instead.
https://github.com/ciromattia/kcc/wiki/Installation#7-zip

![image](https://github.com/ciromattia/kcc/assets/20757319/93b0a2f9-b26f-441b-a0d4-068f1679f3a4)

May be worth a new release since it's a pretty common question.