### PR TITLE
remove dead download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It can also optionally optimize images by applying a number of transformations.
 Amazon's tool is for comic publishers and involves a lot of manual effort, while **KCC** is for comic/manga readers.
 _KC2_ in no way is a replacement for **KCC** so you can be quite confident we are going to carry on developing our little monster ;-)
 
+### Downloads
+
+https://github.com/ciromattia/kcc/releases
+
 ### Issues / new features / donations
 If you have general questions about usage, feedback etc. please [post it here](http://www.mobileread.com/forums/showthread.php?t=207461).
 If you have some **technical** problems using KCC please [file an issue here](https://github.com/ciromattia/kcc/issues/new).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ It can also optionally optimize images by applying a number of transformations.
 Amazon's tool is for comic publishers and involves a lot of manual effort, while **KCC** is for comic/manga readers.
 _KC2_ in no way is a replacement for **KCC** so you can be quite confident we are going to carry on developing our little monster ;-)
 
-### Downloads
-
-https://github.com/ciromattia/kcc/releases
-
 ### Issues / new features / donations
 If you have general questions about usage, feedback etc. please [post it here](http://www.mobileread.com/forums/showthread.php?t=207461).
 If you have some **technical** problems using KCC please [file an issue here](https://github.com/ciromattia/kcc/issues/new).
@@ -42,10 +38,6 @@ You can find the latest binary at the following link:
 - **https://github.com/ciromattia/kcc/releases**
 - flatpak : https://flathub.org/apps/details/io.github.ciromattia.kcc
 - Docker: https://github.com/ciromattia/kcc/pkgs/container/kcc
-
-~~- **[Windows](http://kcc.iosphe.re/Windows/) (64-bit only)**~~  
-~~- **[macOS](http://kcc.iosphe.re/OSX/) (10.14+)**~~  
-~~- **Linux:** Currently unavailable.~~
 
 more information on [installation](https://github.com/ciromattia/kcc/wiki/Installation)
 


### PR DESCRIPTION
KCC website now redirects to GitHub, plus it might confuse people.

Fixes #534