### PR TITLE
Fix unhelpful none error

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -631,7 +631,7 @@ def getWorkFolder(afile):
                 path = cbx.extract(workdir)
             except OSError as e:
                 rmtree(workdir, True)
-                raise UserWarning(e.strerror)
+                raise UserWarning(e)
     else:
         raise UserWarning("Failed to open source file/directory.")
     sanitizePermissions(path)

--- a/kindlecomicconverter/metadata.py
+++ b/kindlecomicconverter/metadata.py
@@ -46,7 +46,7 @@ class MetadataParser:
                 self.rawdata = cbx.extractMetadata()
                 self.format = cbx.type
             except OSError as e:
-                raise UserWarning(e.strerror)
+                raise UserWarning(e)
         if self.rawdata:
             self.parseXML()
 
@@ -121,5 +121,5 @@ class MetadataParser:
                 cbx = comicarchive.ComicArchive(self.source)
                 cbx.addFile(tmpXML)
             except OSError as e:
-                raise UserWarning(e.strerror)
+                raise UserWarning(e)
             rmtree(workdir)


### PR DESCRIPTION
Previously gave unhelpful error message when using rar on mac:
![image](https://github.com/ciromattia/kcc/assets/20757319/3234f6da-7335-4388-a456-5afccf747c6c)

Now gives proper error.

![image](https://github.com/ciromattia/kcc/assets/20757319/816e8690-78a9-4070-b282-331af0b38736)

Also removed all other occurrences of `strerror`

Fixes #528
