### PR TITLE
Default to manga mode and make scribe not upscale 

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -643,6 +643,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         if not GUI.webtoonBox.isChecked():
             GUI.qualityBox.setEnabled(profile['PVOptions'])
         GUI.upscaleBox.setChecked(profile['DefaultUpscale'])
+        GUI.mangaBox.setChecked(True)
         if not profile['PVOptions']:
             GUI.qualityBox.setChecked(False)
         if str(GUI.deviceBox.currentText()) == 'Other':
@@ -931,7 +932,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             "Kindle Voyage": {'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0,
                               'DefaultUpscale': True, 'Label': 'KV'},
             "Kindle Scribe": {
-                'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0, 'DefaultUpscale': True, 'Label': 'KS',
+                'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0, 'DefaultUpscale': False, 'Label': 'KS',
             },
             "Kindle 11": {
                 'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0, 'DefaultUpscale': True, 'Label': 'K11',


### PR DESCRIPTION
Was annoying changing this frequently.

On Kindle Scribe, it will upscale on it's own, so no need to blow up small images. No need to upscale to 1920 in KCC and then let the scribe upscale again to 2480.

Won't matter in most cases since manga is usually 2250. I don't think kindlegen will ever get more than 1920 since there isn't much difference with 2250.

![image](https://github.com/ciromattia/kcc/assets/20757319/160f5e9e-1d65-4743-9054-75a1b1b1c2b0)
