### PR TITLE
Enable double spread on kindle

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -295,13 +295,14 @@ def buildOPF(dstdir, title, filelist, cover=None):
                       "<meta name=\"zero-gutter\" content=\"true\"/>\n",
                       "<meta name=\"zero-margin\" content=\"true\"/>\n",
                       "<meta name=\"ke-border-color\" content=\"#FFFFFF\"/>\n",
-                      "<meta name=\"ke-border-width\" content=\"0\"/>\n"])
+                      "<meta name=\"ke-border-width\" content=\"0\"/>\n",
+                      "<meta property=\"rendition:spread\">landscape</meta>\n",
+                      "<meta property=\"rendition:layout\">pre-paginated</meta>\n",
+                      "<meta name=\"orientation-lock\" content=\"none\"/>\n"])
         if options.kfx:
-            f.writelines(["<meta name=\"orientation-lock\" content=\"none\"/>\n",
-                          "<meta name=\"region-mag\" content=\"false\"/>\n"])
+            f.writelines(["<meta name=\"region-mag\" content=\"false\"/>\n"])
         else:
-            f.writelines(["<meta name=\"orientation-lock\" content=\"portrait\"/>\n",
-                          "<meta name=\"region-mag\" content=\"true\"/>\n"])
+            f.writelines(["<meta name=\"region-mag\" content=\"true\"/>\n"])
     elif options.supportSyntheticSpread:
         f.writelines([
             "<meta property=\"rendition:spread\">landscape</meta>\n",


### PR DESCRIPTION
Following this issue https://github.com/ciromattia/kcc/issues/392, wrote the same metadata used for double spreads on the kobo for the kindle as well. Worked as intended. Below are screenshots on the KW5. 

![screenshot_2023_07_31T18_38_04-0500](https://github.com/ciromattia/kcc/assets/86895685/e2257638-f2fa-46ea-87b6-82743c7d19ac)
![screenshot_2023_07_31T18_38_09-0500](https://github.com/ciromattia/kcc/assets/86895685/26c3243e-c15e-486f-8c3d-f8c9907cac79)
![screenshot_2023_07_31T18_38_21-0500](https://github.com/ciromattia/kcc/assets/86895685/f43a59d2-9bf4-4bae-9869-e35a8e5ecb7c)
![screenshot_2023_07_31T18_38_29-0500](https://github.com/ciromattia/kcc/assets/86895685/7c9bbd11-a36e-4988-b135-2559f9c79e56)

Part of the specification for epubs mentioned here https://github.com/kobolabs/epub-spec#synthetic-spreads, so there shouldn't be an issue for any other ereader either if someone wants to make those changes. 