### PR TITLE
Display kindlegen path

### DIFF
--- a/kcc.py
+++ b/kcc.py
@@ -46,8 +46,8 @@ if sys.platform.startswith('darwin'):
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 elif sys.platform.startswith('win'):
     win_paths = [
-        '%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\',
-        '%LOCALAPPDATA%\\Amazon\\KC2',
+        os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),
+        os.path.expandvars('%LOCALAPPDATA%\\Amazon\\KC2'),
         'C:\\Program Files\\7-Zip',
     ]
     if getattr(sys, 'frozen', False):

--- a/kcc.py
+++ b/kcc.py
@@ -47,6 +47,7 @@ if sys.platform.startswith('darwin'):
 elif sys.platform.startswith('win'):
     win_paths = [
         '%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\',
+        '%LOCALAPPDATA%\\Amazon\\KC2',
         'C:\\Program Files\\7-Zip',
     ]
     if getattr(sys, 'frozen', False):

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -860,12 +860,12 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break
-            if os.name == 'nt':
-                process = subprocess.run('where kindlegen.exe', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-                self.addMessage(f"<b>KindleGen Found:</b> {process.stdout.split()[0].decode('utf-8')}", 'info')
-            elif os.name == 'posix':
-                process = subprocess.run('which kindlegen', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-                self.addMessage(f"<b>KindleGen Found:</b> {process.stdout.split()[0].decode('utf-8')}", 'info')
+            where_command = 'where kindlegen.exe'
+            if os.name == 'posix':
+                where_command = 'which kindlegen'
+            process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
+            locations = process.stdout.decode('utf-8').split('\n')
+            self.addMessage(f"<b>KindleGen Found:</b> {locations[0]}", 'info')
         else:
             self.kindleGen = False
             if startup:

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -18,7 +18,6 @@
 # PERFORMANCE OF THIS SOFTWARE.
 import json
 import os
-import platform
 import re
 import subprocess
 import sys

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -18,7 +18,9 @@
 # PERFORMANCE OF THIS SOFTWARE.
 import json
 import os
+import platform
 import re
+import subprocess
 import sys
 from urllib.parse import unquote
 from urllib.request import urlretrieve, urlopen
@@ -858,6 +860,12 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break
+            if os.name == 'nt':
+                process = subprocess.run('where kindlegen.exe', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
+                self.addMessage(f"<b>KindleGen Found:</b> {process.stdout.split()[0].decode('utf-8')}", 'info')
+            elif os.name == 'posix':
+                process = subprocess.run('which kindlegen', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
+                self.addMessage(f"<b>KindleGen Found:</b> {process.stdout.split()[0].decode('utf-8')}", 'info')
         else:
             self.kindleGen = False
             if startup:

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -756,7 +756,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         if sys.platform.startswith('win'):
             self.addMessage('Download it and place EXE in KCC directory.', 'error')
         elif sys.platform.startswith('darwin'):
-            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation#kindlegen">'
+            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation/_edit#kindlegen">'
                             'Install the kindle-comic-creator cask using Homebrew</a> to enable MOBI conversion',
                             'error')
         else:

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -756,7 +756,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         if sys.platform.startswith('win'):
             self.addMessage('Download it and place EXE in KCC directory.', 'error')
         elif sys.platform.startswith('darwin'):
-            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation/_edit#kindlegen">'
+            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation#kindlegen">'
                             'Install the kindle-comic-creator cask using Homebrew</a> to enable MOBI conversion',
                             'error')
         else:


### PR DESCRIPTION
LOCALAPPDATA doesn't actually work until you expand.

Adding Kindle Comic Creator for completeness, even though its from 2014. 

![image](https://github.com/ciromattia/kcc/assets/20757319/fdbccffc-cf62-4362-8102-3e1be7330dd4)


```
C:\Users\*****\AppData\Local\Amazon\KC2>kindlegen

*************************************************************
 Amazon kindlegen(Windows) V2.9 build 1029-0897292
 A command line e-book compiler
 Copyright Amazon.com and its Affiliates 2014
*************************************************************
```

I just tested however, the Windows version of kindlegen included in Kindle Previewer hangs sometimes. Sounds like a wiki page should clarify. I'll update when there is a new release.

Since the version matters, added logic to show location:

![image](https://github.com/ciromattia/kcc/assets/20757319/120b27da-eaab-468e-b178-6b3cc73cf157)

![image](https://github.com/ciromattia/kcc/assets/20757319/04d62b5f-77e3-4e25-8208-d1ca51a268c7)
