### PR TITLE
prioritize KC2 over KP3 kindlegen version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ $ sudo apt-get install qt5dxcb-plugin
 - KindleGen ~~[(deprecated link)](http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211)~~ v2.9+  (For MOBI generation) 
   - should be placed in a directory reachable by your _PATH_ or in _KCC_ directory
   - `KindleGen` can be found in [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011)
-    `Amazon Kindle Previewer 3 Folder\lib\fc\bin`,    the usual location in windows is in windows is `C:\Users\user\AppData\Local\Amazon\Kindle Previewer 3\lib\fc\bin\`
   - `KindleGen` can be also be found in [Kindle Comic Creator](https://www.amazon.com/b?node=23496309011)
 - [7z](http://www.7-zip.org/download.html) *(For CBZ/ZIP, CBR/RAR, 7z/CB7 support)*
 - Unrar (no rar in 7z on Fedora)

--- a/kcc.py
+++ b/kcc.py
@@ -45,6 +45,7 @@ if sys.platform.startswith('darwin'):
         os.environ['PATH'] += os.pathsep + os.pathsep.join(mac_paths)
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 elif sys.platform.startswith('win'):
+    # prioritize KC2 since KP3 version is buggy as of v3.72
     win_paths = [
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\KC2'),
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),

--- a/kcc.py
+++ b/kcc.py
@@ -27,6 +27,7 @@ if sys.version_info < (3, 8, 0):
 # OS specific workarounds
 import os
 if sys.platform.startswith('darwin'):
+    # prioritize KC2 since it optionally also installs KP3
     mac_paths = [
         '/Applications/Kindle Comic Creator/Kindle Comic Creator.app/Contents/MacOS',
         '/Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/',
@@ -45,7 +46,7 @@ if sys.platform.startswith('darwin'):
         os.environ['PATH'] += os.pathsep + os.pathsep.join(mac_paths)
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 elif sys.platform.startswith('win'):
-    # prioritize KC2 since KP3 version is buggy as of v3.72
+    # prioritize KC2 since it optionally also installs KP3
     win_paths = [
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\KC2'),
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),

--- a/kcc.py
+++ b/kcc.py
@@ -28,8 +28,8 @@ if sys.version_info < (3, 8, 0):
 import os
 if sys.platform.startswith('darwin'):
     mac_paths = [
-        '/Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/',
         '/Applications/Kindle Comic Creator/Kindle Comic Creator.app/Contents/MacOS',
+        '/Applications/Kindle Previewer 3.app/Contents/lib/fc/bin/',
     ]
     if getattr(sys, 'frozen', False):
         os.environ['PATH'] += os.pathsep + os.pathsep.join(mac_paths +
@@ -46,8 +46,8 @@ if sys.platform.startswith('darwin'):
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 elif sys.platform.startswith('win'):
     win_paths = [
-        os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\KC2'),
+        os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),
         'C:\\Program Files\\7-Zip',
     ]
     if getattr(sys, 'frozen', False):

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -751,18 +751,10 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.worker.start()
 
     def display_kindlegen_missing(self):
-        self.addMessage('Cannot find <b>KindleGen</b> from '
-                        '<a href="https://www.amazon.com/b?node=23496309011"><b>Kindle Comic Creator</b></a> or '
-                        '<a href="https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011">'
-                        '<b>Kindle Previewer</b></a>! MOBI conversion is unavailable!', 'error')
-        if sys.platform.startswith('win'):
-            self.addMessage('Download it and place EXE in KCC directory.', 'error')
-        elif sys.platform.startswith('darwin'):
-            self.addMessage('<a href="https://github.com/ciromattia/kcc/wiki/Installation#kindlegen">'
-                            'Install the kindle-comic-creator cask using Homebrew</a> to enable MOBI conversion',
-                            'error')
-        else:
-            self.addMessage('Download it and place executable in /usr/local/bin directory.', 'error')
+        self.addMessage(
+            '<a href="https://github.com/ciromattia/kcc/wiki/Installation#kindlegen"><b>Cannot find KindleGen</b></a>: MOBI conversion is unavailable!', 
+            'error'
+        )
 
     def saveSettings(self, event):
         if self.conversionAlive:


### PR DESCRIPTION
Since KC2 will ask you to install KP3, I'm sure some user will do that.

This is a potential problem since KP3-kindlegen on windows sometimes hangs, so may as well prioritize the older version from KC2. 

KCC v5.6.3 does not search for KP3 or KC2 on Windows. Will need a new release since we merged in #571  afterward. I think installing KC2 is way simpler than moving `kindlegen.exe` from web archive around.

![image](https://github.com/ciromattia/kcc/assets/20757319/866444ba-b3e2-42db-864f-703720f0dea4)

links here: https://github.com/ciromattia/kcc/wiki/Installation#kindlegen

Fixes #573 
