### PR TITLE
fix page order in pdf and more by using natural sort instead of python sort

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -31,6 +31,7 @@ from tempfile import mkdtemp, gettempdir, TemporaryFile
 from shutil import move, copytree, rmtree, copyfile
 from multiprocessing import Pool
 from uuid import uuid4
+from natsort import natsorted
 from slugify import slugify as slugify_ext
 from PIL import Image
 from subprocess import STDOUT, PIPE
@@ -761,7 +762,7 @@ def getPanelViewSize(deviceres, size):
 def sanitizeTree(filetree):
     chapterNames = {}
     for root, dirs, files in os.walk(filetree, False):
-        for i, name in enumerate(sorted(files)):
+        for i, name in enumerate(natsorted(files)):
             splitname = os.path.splitext(name)
 
             # file needs kcc at front AND back to avoid renaming issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ python-slugify>=1.2.1
 raven>=6.0.0
 # PyQt5-tools
 mozjpeg-lossless-optimization>=1.1.2
+natsort>=8.4.0
 distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ python-slugify>=1.2.1
 raven>=6.0.0
 # PyQt5-tools
 mozjpeg-lossless-optimization>=1.1.2
-natsort>=8.4.0
+natsort[fast]>=8.4.0
 distro


### PR DESCRIPTION
Fixes #587
Fixes #595

So that's why we did number padding in the old sort method. 

Related: #507 

Prebuilt binaries for download for normal user testing:

Windows EXE: https://github.com/axu2/kcc/actions/runs/6123144358
Mac DMG: https://github.com/axu2/kcc/actions/runs/6123143150
Linux: https://github.com/axu2/kcc/actions/runs/6793159103