### PR TITLE
lower auto crop threshold from 0.045 to 0.015

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -24,12 +24,7 @@ import mozjpeg_lossless_optimization
 from PIL import Image, ImageOps, ImageStat, ImageChops, ImageFilter
 from .shared import md5Checksum
 
-# 0.045 was determined by
-# 1200 / 824 = 1.456 (Kindle DX resolution)
-# 2250 / 1500 = 1.5 (Typical manga page resolution)
-# 1.5 - 1.456 < 0.045
-# 0.045 / 1.5 = 0.03 (So maximum 3% of is cropped)
-AUTO_CROP_THRESHOLD = 0.045
+AUTO_CROP_THRESHOLD = 0.015
 
 
 class ProfileData:


### PR DESCRIPTION
I'll have the larger threshold be toggle-able to avoid issues like #585 in a future PR. In that case he had undesirable cropping at 0.043. And at that point may as well make it a 3-way toggle with 0/0.015/0.045.

I just eyeballed the threshold with various images. On my Kindle Scribe, this translates to a 10 pixel border on the sides that get cropped out.

Fixes #585 
