### PR TITLE
fix kobo file names with .

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -19,6 +19,8 @@
 #
 
 import os
+import pathlib
+import re
 import subprocess
 import sys
 from argparse import ArgumentParser
@@ -673,11 +675,9 @@ def getOutputFilename(srcpath, wantedname, ext, tomenumber):
         filename = srcpath + tomenumber + ext
     else:
         if 'Ko' in options.profile and options.format == 'EPUB':
-            path = srcpath.split(os.path.sep)
-            path[-1] = ''.join(e for e in path[-1].split('.')[0] if e.isalnum()) + tomenumber + ext
-            if not path[-1].split('.')[0]:
-                path[-1] = 'KCCPlaceholder' + tomenumber + ext
-            filename = os.path.sep.join(path)
+            src = pathlib.Path(srcpath)
+            name = re.sub(r'\W+', '_', src.stem) + tomenumber + ext
+            filename = src.with_name(name)
         else:
             filename = os.path.splitext(srcpath)[0] + tomenumber + ext
     if os.path.isfile(filename):


### PR DESCRIPTION
Prebuilt binaries for normal user testing (also contains recent error logging changes):

Windows: https://github.com/axu2/kcc/actions/runs/6853834938
Mac: https://github.com/axu2/kcc/actions/runs/6853836566
Linux: https://github.com/axu2/kcc/actions/runs/6853837839
 
- Fixes #615 

@HamzaM
@vietvu94 
Can you verify if this fixes your issue?

Various characters are illegal in older EPUB readers, including spaces. https://www.w3.org/TR/epub-33/#sec-container-filenames

Code based on: https://stackoverflow.com/questions/12985456/replace-all-non-alphanumeric-characters-in-a-string

Before and after:

![image](https://github.com/ciromattia/kcc/assets/20757319/5391e449-df21-4507-8e4a-55eed11f75f1)

I do not have a kobo to test so there's no way for me to verify if this build causes other issues. 