### PR TITLE
fix "Unsupported archive format" 

### DIFF
--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -46,11 +46,7 @@ class ComicArchive:
                     self.type = line.rstrip().split(' ')[1].upper()
                     break
             if process.returncode != 0:
-                raise OSError('Archive is corrupted or encrypted.')
-            elif self.type not in ['7Z', 'RAR', 'RAR5', 'ZIP']:
-                raise OSError('Unsupported archive format.')
-        elif self.type not in ['7Z', 'RAR', 'RAR5', 'ZIP']:
-            raise OSError('Unsupported archive format.')
+                raise OSError(process.stdout.strip())
 
     def extract(self, targetdir):
         if not os.path.isdir(targetdir):


### PR DESCRIPTION
Prebuilt versions for non-coder user testing:
windows: https://github.com/axu2/kcc/actions/runs/6908330252
mac: https://github.com/axu2/kcc/actions/runs/6908329301
Linux: https://github.com/axu2/kcc/actions/runs/6908328152

This is a common error I've seen.

There's no point in erroring out pre-maturely. If it errors, it should error at extraction time, not when checking hardcoded conditions. I've never replicated the error myself, but I suspect that our conditions are lacking.

fixes #596 