### PR TITLE
fix list index out of range by skipping bookmarks when splitting mobi

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -728,7 +728,7 @@ def getComicInfo(path, originalpath):
             options.authors.sort()
         else:
             options.authors = ['KCC']
-        if xml.data['Bookmarks']:
+        if xml.data['Bookmarks'] and options.batchsplit == 0:
             options.chapters = xml.data['Bookmarks']
         if xml.data['Summary']:
             options.summary = hescape(xml.data['Summary'])


### PR DESCRIPTION
Prebuilt binaries for normal user testing:
windows: https://github.com/axu2/kcc/actions/runs/6918518314
mac: https://github.com/axu2/kcc/actions/runs/6918517538
linux: https://github.com/axu2/kcc/actions/runs/6918515994

Skip bookmarks if book is being split into multiple files to avoid list index out of range. functionally equivalent to deleting the comicinfo.xml file.


Fixes #582 
Fixes #586 
Fixes #556 
Fixes #368 
Fixes #352 
Fixes #345 
fixes #229 
fixes #219 


@Tamamaster @DemonEye888 Can you test if this fixes your issue? Works for me with your provided test file.