### PR TITLE
Speed up mac startup from 17 seconds to 1 second by not using -F flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class BuildBinaryCommand(distutils.cmd.Command):
     def run(self):
         VERSION = __version__
         if sys.platform == 'darwin':
-            os.system('pyinstaller -y -F -i icons/comic2ebook.icns -n "Kindle Comic Converter" -w -s kcc.py')
+            os.system('pyinstaller -y -D -i icons/comic2ebook.icns -n "Kindle Comic Converter" -w -s kcc.py')
             # TODO /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Applications/Kindle\ Comic\ Converter.app -v
             os.system('appdmg kcc.json dist/KindleComicConverter_osx_' + VERSION + '.dmg')
             sys.exit(0)


### PR DESCRIPTION
Known issue when using QT and pyinstaller: 

https://stackoverflow.com/questions/9469932/app-created-with-pyinstaller-has-a-slow-startup

Using an m2 mac. 17 seconds before rosetta translation and 1 second after rosetta translation.

sample build: https://github.com/axu2/kcc/actions/runs/6938502629

@ronnyhammurabi can you please test this as well? Maybe this was your issue
Use this version with the unsupported archive error merged in: https://github.com/axu2/kcc/actions/runs/6938583635

Onefile doesn't matter since it get packed  into a .app anyways