### PR TITLE
 streamline downloads and installation readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On Windows 11, you may need to run in compatibility mode for an older Windows ve
 
 On Mac, right click open to get past the security warning.
 
-For flatpak and Docker versions, refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation
+For flatpak, Docker, amd AppImage versions, refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation
 
 ## INSTALL DEPENDENCIES
 
@@ -75,11 +75,6 @@ brew install unar
 #### Windows / macOS KindleGen
 
 Install [Kindle Previewer 3 (KP3)](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011). KCC will automatically detect KindleGen from it.
-
-An older version of KindleGen can be automatically detected from [Kindle Comic Creator (KC2)](https://www.amazon.com/Kindle-Comic-Creator/b?ie=UTF8&node=23496309011) as backup in case you have issues with KP3.
-
-For Linux users or those wanting more info refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation
-
 
 ## INPUT FORMATS
 **KCC** can understand and convert, at the moment, the following input types:

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ The installation process has been greatly streamlined. No need to add 7z to PATH
 
 ### 7-Zip
 
-#### Windows
+#### Windows 7-Zip
 
 First install 7z from https://www.7-zip.org/ or with command line:
 ```
 winget install --id 7zip.7zip
 ```
 
-#### macOS
+#### macOS 7-Zip/Unar
 with [Homebrew](https://brew.sh/) installed
 ```
 brew install p7zip
@@ -72,7 +72,7 @@ brew install unar
 
 ### KindleGen
 
-#### Windows / macOS
+#### Windows / macOS KindleGen
 
 Install [Kindle Previewer 3 (KP3)](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011). KCC will automatically detect KindleGen from it.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ If you find **KCC** valuable you can consider donating to the authors:
   - [![Donate Bitcoin](https://img.shields.io/badge/Donate-Bitcoin-green.svg)](https://jastrzeb.ski/donate/)
 
 
-## INSTALLATION 
-
-### DOWNLOADS
+## DOWNLOADS
 
 - **https://github.com/ciromattia/kcc/releases**
 
@@ -44,44 +42,41 @@ You probably want either
 
 The `c2e` and `c2p` versions are command line tools for power users.
 
-Installation Wiki: https://github.com/ciromattia/kcc/wiki/Installation
+On Windows 11, you may need to run in compatibility mode for an older Windows version.
 
-- flatpak : https://flathub.org/apps/details/io.github.ciromattia.kcc
-- Docker: https://github.com/ciromattia/kcc/pkgs/container/kcc
+On Mac, right click open to get past the security warning.
 
-### DEPENDENCIES
-Following software is required to run Linux version of **KCC** and/or bare sources:
-- Python 3.3+
-- [PyQt5](https://pypi.python.org/pypi/PyQt5) 5.6.0+ (only needed for GUI)
-- [Pillow](https://pypi.python.org/pypi/Pillow/) 4.0.0+ (5.2.0+ needed for WebP support)
-- [psutil](https://pypi.python.org/pypi/psutil) 5.0.0+
-- [python-slugify](https://pypi.python.org/pypi/python-slugify) 1.2.1+, <8.0.0
-- [raven](https://pypi.python.org/pypi/raven) 6.0.0+ (only needed for GUI)
+## INSTALL DEPENDENCIES
 
-On Debian based distributions these two commands should install all needed dependencies:
+You'll need to install various tools to access important but optional features.
 
+The installation process has been greatly streamlined. No need to add 7z to PATH or locate KindleGen from the internet and put it in a special folder with KCC. Just run it and KCC will tell you what to install.
 
+### 7-Zip
 
-```bash
-$ sudo apt-get install -y python3 python3-dev libpng-dev libjpeg-dev p7zip-full p7zip-rar unrar-free libgl1 python3-pyqt5 && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --upgrade -r requirements.txt
+#### Windows
+
+First install 7z from https://www.7-zip.org/ or with command line:
+```
+winget install --id 7zip.7zip
 ```
 
-
-#### Optional dependencies
-- Qt platform integration plugin for Deepin Desktop Environment
-```bash
-$ sudo apt-get install qt5dxcb-plugin
+#### macOS
+with [Homebrew](https://brew.sh/) installed
+```
+brew install p7zip
+brew install unar
 ```
 
-- KindleGen ~~[(deprecated link)](http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211)~~ v2.9+  (For MOBI generation) 
-  - should be placed in a directory reachable by your _PATH_ or in _KCC_ directory
-  - `KindleGen` can be found in [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011)
-  - `KindleGen` can be also be found in [Kindle Comic Creator](https://www.amazon.com/b?node=23496309011)
-- [7z](http://www.7-zip.org/download.html) *(For CBZ/ZIP, CBR/RAR, 7z/CB7 support)*
-- Unrar (no rar in 7z on Fedora)
+### KindleGen
 
+#### Windows / macOS
+
+Install [Kindle Previewer 3 (KP3)](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011). KCC will automatically detect KindleGen from it.
+
+An older version of KindleGen can be automatically detected from [Kindle Comic Creator (KC2)](https://www.amazon.com/Kindle-Comic-Creator/b?ie=UTF8&node=23496309011) as backup in case you have issues with KP3.
+
+For Linux users or those wanting more info refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation
 
 
 ## INPUT FORMATS

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ On Windows 11, you may need to run in compatibility mode for an older Windows ve
 
 On Mac, right click open to get past the security warning.
 
+For flatpak and Docker versions, refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation
+
 ## INSTALL DEPENDENCIES
 
 You'll need to install various tools to access important but optional features.


### PR DESCRIPTION
I find users are still having trouble figuring out how to download and run KCC on Windows from comments on various forums.

I streamlined the readme and moved a lot of linux stuff into the wiki.

Now windows and mac users only need to refer to readme, which comprise 90% of downloads. Since the process is now standardized and not gonna change. https://somsubhra.github.io/github-release-stats/?username=ciromattia&repository=kcc&page=1&per_page=5

I'm not sure where to properly put linux stuff since I don't use linux, feel free to edit my PR with info.

