### PR TITLE
make c2e and c2p versions last in file order

### DIFF
--- a/.github/workflows/package-windows-with-docker.yml
+++ b/.github/workflows/package-windows-with-docker.yml
@@ -44,8 +44,8 @@ jobs:
         run: |   
           version_built=$(cat kindlecomicconverter/__init__.py | grep version | awk '{print $3}' | sed "s/[^.0-9b]//g")
           mv dist/windows/kcc.exe dist/windows/kcc_${version_built}.exe 
-          mv dist/windows/kcc-c2e.exe dist/windows/kcc-c2e_${version_built}.exe 
-          mv dist/windows/kcc-c2p.exe dist/windows/kcc-c2p_${version_built}.exe
+          mv dist/windows/kcc-c2e.exe dist/windows/kcc_c2e_${version_built}.exe 
+          mv dist/windows/kcc-c2p.exe dist/windows/kcc_c2p_${version_built}.exe
       - name: upload build
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I noticed lots of people just download all the files since the GUI version is 3rd in the list. This should make it a little easier. Hopefully reduce the number of people who download the CLI version by accident and cant use.

Also, I'm still open to being added as a collaborator if you need help with issues and releases. It feels bad to leave new bugs in for months.

before:
![image](https://github.com/ciromattia/kcc/assets/20757319/471d3cd3-a195-4858-8c3c-e4284aac05c4)
after:
![image](https://github.com/ciromattia/kcc/assets/20757319/2d2ab10a-9d94-45b4-bb0b-2f6ab62ef37e)

