### PR TITLE
 fix p7zip-rar error and files with ' or " by using arg lists instead of strings

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -29,7 +29,7 @@ from subprocess import STDOUT, PIPE
 # noinspection PyUnresolvedReferences
 from PyQt5 import QtGui, QtCore, QtWidgets, QtNetwork
 from xml.sax.saxutils import escape
-from psutil import Popen, Process
+from psutil import Process
 from copy import copy
 from distutils.version import StrictVersion
 from raven import Client
@@ -839,24 +839,22 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                 os.chmod('/usr/local/bin/kindlegen', 0o755)
             except Exception:
                 pass
-        kindleGenExitCode = Popen('kindlegen -locale en', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        kindleGenExitCode.communicate()
+        kindleGenExitCode = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
         if kindleGenExitCode.returncode == 0:
             self.kindleGen = True
-            versionCheck = Popen('kindlegen -locale en', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-            for line in versionCheck.stdout:
-                line = line.decode("utf-8")
+            versionCheck = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+            for line in versionCheck.stdout.splitlines():
                 if 'Amazon kindlegen' in line:
                     versionCheck = line.split('V')[1].split(' ')[0]
                     if StrictVersion(versionCheck) < StrictVersion('2.9'):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break
-            where_command = 'where kindlegen.exe'
+            where_command = ['where', 'kindlegen.exe']
             if os.name == 'posix':
-                where_command = 'which kindlegen'
-            process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-            locations = process.stdout.decode('utf-8').split('\n')
+                where_command = ['which', 'kindlegen']
+            process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+            locations = process.stdout.splitlines()
             self.addMessage(f"<b>KindleGen Found:</b> {locations[0]}", 'info')
         else:
             self.kindleGen = False
@@ -1039,8 +1037,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.addMessage('Since you are a new user of <b>KCC</b> please see few '
                             '<a href="https://github.com/ciromattia/kcc/wiki/Important-tips">important tips</a>.',
                             'info')
-        process = Popen('7z', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        process.communicate()
+        process = subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
         if process.returncode == 0 or process.returncode == 7:
             self.sevenzip = True
         else:

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -839,10 +839,9 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                 os.chmod('/usr/local/bin/kindlegen', 0o755)
             except Exception:
                 pass
-        kindleGenExitCode = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
-        if kindleGenExitCode.returncode == 0:
-            self.kindleGen = True
+        try:
             versionCheck = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+            self.kindleGen = True
             for line in versionCheck.stdout.splitlines():
                 if 'Amazon kindlegen' in line:
                     versionCheck = line.split('V')[1].split(' ')[0]
@@ -856,12 +855,10 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
             locations = process.stdout.splitlines()
             self.addMessage(f"<b>KindleGen Found:</b> {locations[0]}", 'info')
-        else:
+        except FileNotFoundError:
             self.kindleGen = False
             if startup:
                 self.display_kindlegen_missing()
-
-
 
     def __init__(self, kccapp, kccwindow):
         global APP, MW, GUI
@@ -1037,10 +1034,10 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.addMessage('Since you are a new user of <b>KCC</b> please see few '
                             '<a href="https://github.com/ciromattia/kcc/wiki/Important-tips">important tips</a>.',
                             'info')
-        process = subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
-        if process.returncode == 0 or process.returncode == 7:
+        try:
+            subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
             self.sevenzip = True
-        else:
+        except FileNotFoundError:
             self.sevenzip = False
             self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
                             ' to enable CBZ/CBR/ZIP/etc processing.', 'warning')

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -849,12 +849,6 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break
-            where_command = ['where', 'kindlegen.exe']
-            if os.name == 'posix':
-                where_command = ['which', 'kindlegen']
-            process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
-            locations = process.stdout.splitlines()
-            self.addMessage(f"<b>KindleGen Found:</b> {locations[0]}", 'info')
         except FileNotFoundError:
             self.kindleGen = False
             if startup:

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1103,13 +1103,15 @@ def checkTools(source):
     source = source.upper()
     if source.endswith('.CB7') or source.endswith('.7Z') or source.endswith('.RAR') or source.endswith('.CBR') or \
             source.endswith('.ZIP') or source.endswith('.CBZ'):
-        process = subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
-        if process.returncode != 0 and process.returncode != 7:
+        try:
+            subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
+        except FileNotFoundError:
             print('ERROR: 7z is missing!')
             sys.exit(1)
     if options.format == 'MOBI':
-        kindleGenExitCode = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT)
-        if kindleGenExitCode.returncode != 0:
+        try:
+            subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT)
+        except FileNotFoundError:
             print('ERROR: KindleGen is missing!')
             sys.exit(1)
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -19,6 +19,7 @@
 #
 
 import os
+import subprocess
 import sys
 from argparse import ArgumentParser
 from time import strftime, gmtime
@@ -35,7 +36,7 @@ from natsort import natsorted
 from slugify import slugify as slugify_ext
 from PIL import Image
 from subprocess import STDOUT, PIPE
-from psutil import Popen, virtual_memory, disk_usage
+from psutil import virtual_memory, disk_usage
 from html import escape as hescape
 try:
     from PyQt5 import QtCore
@@ -1102,14 +1103,12 @@ def checkTools(source):
     source = source.upper()
     if source.endswith('.CB7') or source.endswith('.7Z') or source.endswith('.RAR') or source.endswith('.CBR') or \
             source.endswith('.ZIP') or source.endswith('.CBZ'):
-        process = Popen('7z', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        process.communicate()
+        process = subprocess.run(['7z'], stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0 and process.returncode != 7:
             print('ERROR: 7z is missing!')
             sys.exit(1)
     if options.format == 'MOBI':
-        kindleGenExitCode = Popen('kindlegen -locale en', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        kindleGenExitCode.communicate()
+        kindleGenExitCode = subprocess.run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT)
         if kindleGenExitCode.returncode != 0:
             print('ERROR: KindleGen is missing!')
             sys.exit(1)
@@ -1266,10 +1265,9 @@ def makeMOBIWorker(item):
     kindlegenError = ''
     try:
         if os.path.getsize(item) < 629145600:
-            output = Popen('kindlegen -dont_append_source -locale en "' + item + '"',
-                           stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-            for line in output.stdout:
-                line = line.decode('utf-8')
+            output = subprocess.run(['kindlegen', '-dont_append_source', '-locale', 'en', item],
+                           stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+            for line in output.stdout.splitlines():
                 # ERROR: Generic error
                 if "Error(" in line:
                     kindlegenErrorCode = 1
@@ -1280,7 +1278,6 @@ def makeMOBIWorker(item):
                 if kindlegenErrorCode > 0:
                     break
                 if ":I1036: Mobi file built successfully" in line:
-                    output.communicate()
                     break
         else:
             # ERROR: EPUB too big

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -82,7 +82,7 @@ class ComicArchive:
 
     def extractMetadata(self):
         process = subprocess.run(['7z', 'x', '-y', '-so', self.filepath, 'ComicInfo.xml'],
-                        stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+                        stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0:
             raise OSError('Failed to extract archive.')
         try:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -61,8 +61,6 @@ class ComicArchive:
         elif process.returncode != 0 and platform.system() == 'Darwin':
             process = subprocess.run(['unar', self.filepath, '-f', '-o', targetdir], 
                 stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
-            if process.returncode != 0:
-                raise Exception(process.stdout)
         elif process.returncode != 0:
             raise OSError(process.stdout.strip())
         tdir = os.listdir(targetdir)

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -62,7 +62,7 @@ class ComicArchive:
             process = subprocess.run(['unar', self.filepath, '-f', '-o', targetdir], 
                 stdout=PIPE, stderr=STDOUT)
         elif process.returncode != 0:
-            raise OSError(process.stdout.strip())
+            raise OSError('Failed to extract archive. Try extracting the file outside of KCC.')
         tdir = os.listdir(targetdir)
         if 'ComicInfo.xml' in tdir:
             tdir.remove('ComicInfo.xml')

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -52,7 +52,6 @@ class ComicArchive:
                 raise OSError(EXTRACTION_ERROR)
 
     def extract(self, targetdir):
-        raise OSError(EXTRACTION_ERROR)
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
         process = subprocess.run(['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -36,7 +36,6 @@ class ComicArchive:
         self.type = None
         if not os.path.isfile(self.filepath):
             raise OSError('File not found.')
-        # encoding the output of 7z on Windows to UTF-8 can cause issues
         process = subprocess.run(['7z', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE)
         for line in process.stdout.splitlines():
             if b'Type =' in line:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -27,8 +27,8 @@ from subprocess import STDOUT, PIPE
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
 
+EXTRACTION_ERROR = 'Failed to extract archive. Try extracting file outside of KCC.'
 
-EXTRACTION_ERROR = 'Failed to extract archive. Try extracting file outside of KCC and using the extracted folder directly.'
 
 class ComicArchive:
     def __init__(self, filepath):
@@ -52,6 +52,7 @@ class ComicArchive:
                 raise OSError(EXTRACTION_ERROR)
 
     def extract(self, targetdir):
+        raise OSError(EXTRACTION_ERROR)
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
         process = subprocess.run(['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -52,7 +52,7 @@ class ComicArchive:
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
         process = subprocess.run(['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
-                                 stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+                                 stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0 and distro.id() == 'fedora':
             process = subprocess.run(['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir] 
                     , stdout=PIPE, stderr=STDOUT)
@@ -60,7 +60,7 @@ class ComicArchive:
                 raise OSError('Failed to extract archive.')
         elif process.returncode != 0 and platform.system() == 'Darwin':
             process = subprocess.run(['unar', self.filepath, '-f', '-o', targetdir], 
-                stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+                stdout=PIPE, stderr=STDOUT)
         elif process.returncode != 0:
             raise OSError(process.stdout.strip())
         tdir = os.listdir(targetdir)

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -22,7 +22,6 @@ import os
 import platform
 import subprocess
 import distro
-from psutil import Popen
 from shutil import move
 from subprocess import STDOUT, PIPE
 from xml.dom.minidom import parseString
@@ -35,41 +34,37 @@ class ComicArchive:
         self.type = None
         if not os.path.isfile(self.filepath):
             raise OSError('File not found.')
-        process = Popen('7z l -y -p1 "' + self.filepath + '"', stderr=STDOUT, stdout=PIPE, stdin=PIPE, shell=True)
-        for line in process.stdout:
-            if b'Type =' in line:
-                self.type = line.rstrip().decode().split(' = ')[1].upper()
+        process = subprocess.run(['7z', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE, encoding='UTF-8')
+        for line in process.stdout.splitlines():
+            if 'Type =' in line:
+                self.type = line.rstrip().split(' = ')[1].upper()
                 break
-        process.communicate()
         if process.returncode != 0 and distro.id() == 'fedora':
-            process = Popen('unrar l -y -p1 "' + self.filepath + '"', stderr=STDOUT, stdout=PIPE, stdin=PIPE, shell=True)
-            for line in process.stdout:
-                if b'Details: ' in line:
-                    self.type = line.rstrip().decode().split(' ')[1].upper()
+            process = subprocess.run(['unrar', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE, encoding='UTF-8')
+            for line in process.stdout.splitlines():
+                if 'Details: ' in line:
+                    self.type = line.rstrip().split(' ')[1].upper()
                     break
-            process.communicate()
             if process.returncode != 0:
                 raise OSError(process.stdout.strip())
 
     def extract(self, targetdir):
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
-        process = Popen('7z x -y -xr!__MACOSX -xr!.DS_Store -xr!thumbs.db -xr!Thumbs.db -o"' + targetdir + '" "' +
-                        self.filepath + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        process.communicate()
+        process = subprocess.run(['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
+                                 stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
         if process.returncode != 0 and distro.id() == 'fedora':
-            process = Popen('unrar x -y -x__MACOSX -x.DS_Store -xthumbs.db -xThumbs.db "' + self.filepath + '" "' +
-                    targetdir + '"', stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-            process.communicate()
+            process = subprocess.run(['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir] 
+                    , stdout=PIPE, stderr=STDOUT)
             if process.returncode != 0:
                 raise OSError('Failed to extract archive.')
         elif process.returncode != 0 and platform.system() == 'Darwin':
-            process = subprocess.run(f"unar '{self.filepath}' -f -o '{targetdir}'", 
-                stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
+            process = subprocess.run(['unar', self.filepath, '-f', '-o', targetdir], 
+                stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
             if process.returncode != 0:
-                raise Exception(process.stdout.decode("utf-8"))
+                raise Exception(process.stdout)
         elif process.returncode != 0:
-            raise OSError('Failed to extract archive. Check if p7zip-rar is installed.')
+            raise OSError(process.stdout.strip())
         tdir = os.listdir(targetdir)
         if 'ComicInfo.xml' in tdir:
             tdir.remove('ComicInfo.xml')
@@ -82,19 +77,17 @@ class ComicArchive:
     def addFile(self, sourcefile):
         if self.type in ['RAR', 'RAR5']:
             raise NotImplementedError
-        process = Popen('7z a -y "' + self.filepath + '" "' + sourcefile + '"',
-                        stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        process.communicate()
+        process = subprocess.run(['7z', 'a', '-y', self.filepath, sourcefile],
+                        stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0:
             raise OSError('Failed to add the file.')
 
     def extractMetadata(self):
-        process = Popen('7z x -y -so "' + self.filepath + '" ComicInfo.xml',
-                        stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-        xml = process.communicate()
+        process = subprocess.run(['7z', 'x', '-y', '-so', self.filepath, 'ComicInfo.xml'],
+                        stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
         if process.returncode != 0:
             raise OSError('Failed to extract archive.')
         try:
-            return parseString(xml[0])
+            return parseString(process.stdout)
         except ExpatError:
             return None

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -34,16 +34,16 @@ class ComicArchive:
         self.type = None
         if not os.path.isfile(self.filepath):
             raise OSError('File not found.')
-        process = subprocess.run(['7z', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE, encoding='UTF-8')
+        process = subprocess.run(['7z', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE)
         for line in process.stdout.splitlines():
-            if 'Type =' in line:
-                self.type = line.rstrip().split(' = ')[1].upper()
+            if b'Type =' in line:
+                self.type = line.rstrip().decode().split(' = ')[1].upper()
                 break
         if process.returncode != 0 and distro.id() == 'fedora':
-            process = subprocess.run(['unrar', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE, encoding='UTF-8')
+            process = subprocess.run(['unrar', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE)
             for line in process.stdout.splitlines():
-                if 'Details: ' in line:
-                    self.type = line.rstrip().split(' ')[1].upper()
+                if b'Details: ' in line:
+                    self.type = line.rstrip().decode().split(' ')[1].upper()
                     break
             if process.returncode != 0:
                 raise OSError(process.stdout.strip())


### PR DESCRIPTION
Not using the slightly unsafe `shell=True` parameter will actually throw a `FileNotFoundError` if I call a command that doesn't exist (like if kindlegen or 7z aren't installed). Called out explicitly here: 

https://docs.python.org/3/library/subprocess.html#exceptions

So prior code in #581 actually crashed when 7z and kindlegen aren't installed during the initial check. Our code prevent selecting MOBI/zip formats afterward, so no further exceptions expected.

So added try: except blocks as needed during initial checks. 