### PR TITLE
add FAT to list of drives for kindle cover generation

### DIFF
--- a/kindlecomicconverter/kindle.py
+++ b/kindlecomicconverter/kindle.py
@@ -31,8 +31,7 @@ class Kindle:
     def findDevice(self):
         for drive in reversed(psutil.disk_partitions(False)):
             if (drive[2] == 'FAT32' and drive[3] == 'rw,removable') or \
-               (drive[2] == 'vfat' and 'rw' in drive[3]) or \
-               (drive[2] == 'msdos' and 'rw' in drive[3]):
+               (drive[2] in ('vfat', 'msdos', 'FAT') and 'rw' in drive[3]):
                 if os.path.isdir(os.path.join(drive[1], 'system')) and \
                         os.path.isdir(os.path.join(drive[1], 'documents')):
                     return drive[1]


### PR DESCRIPTION
Since Windows can only format non-removable virtual hard drive (VHD) to FAT, which pretends to be a kindle for cover upload purposes. FAT32 is also an option but I don't want to touch the FAT32 related code.
https://github.com/ciromattia/kcc/blob/master/kindlecomicconverter/kindle.py#L33
- Related #508 