### PR TITLE
fix utf-8 error by removing kindlegen location from GUI

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -852,12 +852,6 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break
-            where_command = 'where kindlegen.exe'
-            if os.name == 'posix':
-                where_command = 'which kindlegen'
-            process = subprocess.run(where_command, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
-            locations = process.stdout.decode('utf-8').split('\n')
-            self.addMessage(f"<b>KindleGen Found:</b> {locations[0]}", 'info')
         else:
             self.kindleGen = False
             if startup:


### PR DESCRIPTION
- Fix #637 

I'm not sure why this causes an issue but it's not really necessary. Nobody else has had a KP3 issue which this check was for. No need to expose usernames in GUI either

https://github.com/axu2/kcc/actions/runs/7131952387