### PR TITLE
Added natsort to the dependency list in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - python-slugify>=1.2.1
   - raven>=6.0.0
   - distro
+  - natsort[fast]>=8.4.0
   - pip
   - pip:
     - mozjpeg-lossless-optimization>=1.1.2


### PR DESCRIPTION
Issue: #641 

This adds missing `natsort` to the list of dependencies in *environment.yml*.
Versioning is kept the same as in *requirements.txt*.