### PR TITLE
use os_sorted natsort with IGNORECASE

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -31,7 +31,7 @@ from tempfile import mkdtemp, gettempdir, TemporaryFile
 from shutil import move, copytree, rmtree, copyfile
 from multiprocessing import Pool
 from uuid import uuid4
-from natsort import natsorted
+from natsort import os_sorted
 from slugify import slugify as slugify_ext
 from PIL import Image
 from subprocess import STDOUT, PIPE
@@ -762,7 +762,7 @@ def getPanelViewSize(deviceres, size):
 def sanitizeTree(filetree):
     chapterNames = {}
     for root, dirs, files in os.walk(filetree, False):
-        for i, name in enumerate(natsorted(files)):
+        for i, name in enumerate(os_sorted(files)):
             splitname = os.path.splitext(name)
 
             # file needs kcc at front AND back to avoid renaming issues


### PR DESCRIPTION
I was having issue with files in mixed casing, which File Explorer and Finder ignore.


![Screenshot 2023-12-16 at 5 08 57 PM](https://github.com/ciromattia/kcc/assets/20757319/39e9bc09-218b-4b43-bbf7-51b758825832)

![image](https://github.com/ciromattia/kcc/assets/20757319/9f2a6b66-9bb0-4966-bb0a-2c7e5259cd8a)


https://natsort.readthedocs.io/en/stable/api.html#natsort.os_sorted

On Windows, it matches Windows File Explorer behavior.
On macOS without pyicu installed, it just does what natsort does while also ignoring extensions and ignoring case. The drawbacks of using it without pyicu seem to not matter in our case. pyicu isn't a simple pip install, so if I don't have to add it that's good.



