### PR TITLE
rename kindle 11 to kindle basic 11

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -919,7 +919,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             "Kindle Scribe": {
                 'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0, 'DefaultUpscale': False, 'Label': 'KS',
             },
-            "Kindle 11": {
+            "Kindle Basic 11": {
                 'PVOptions': True, 'ForceExpert': False, 'DefaultFormat': 0, 'DefaultUpscale': True, 'Label': 'K11',
             },
             "Kindle PW 5": {
@@ -977,7 +977,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         profilesGUI = [
             "Kindle Oasis 2/3",
             "Kindle PW 5",
-            "Kindle 11",
+            "Kindle Basic 11",
             "Kindle Scribe",
             "Separator",
             "Kobo Clara 2E",


### PR DESCRIPTION
Way too many people are using Kindle 11 when they have a PW5 (11th gen)

Honestly, a little confusing to refer to some by model revisions and some by generations...

![image](https://github.com/ciromattia/kcc/assets/20757319/6d93e242-7457-4bd9-924f-e9ee5421ca84)
![image](https://github.com/ciromattia/kcc/assets/20757319/6b0b5ff4-764b-4c58-9e0b-1c92f66ef6a3)
