### PR TITLE
fix Shift+Click convert button to select output directory renaming

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -260,6 +260,8 @@ class WorkerThread(QtCore.QThread):
         if GUI.currentMode > 2:
             options.customwidth = str(GUI.widthBox.value())
             options.customheight = str(GUI.heightBox.value())
+        if GUI.targetDirectory != '':
+            options.output = GUI.targetDirectory
 
         for i in range(GUI.jobList.count()):
             # Make sure that we don't consider any system message as job to do


### PR DESCRIPTION
- Fix #652 

Add missing options dictionary parameter to allow search on a different folder for files with the same name.

Reporter confirmed that the behaviour is now working correctly: https://github.com/ciromattia/kcc/issues/652#issuecomment-1874129713