### PR TITLE
reset saved GUI settings

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -863,7 +863,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         self.setupUi(MW)
         self.editor = KCCGUI_MetaEditor()
         self.icons = Icons()
-        self.settings = QtCore.QSettings('KindleComicConverter', 'KindleComicConverter')
+        self.settings = QtCore.QSettings('ciromattia', 'kcc')
         self.settingsVersion = self.settings.value('settingsVersion', '', type=str)
         self.lastPath = self.settings.value('lastPath', '', type=str)
         self.lastDevice = self.settings.value('lastDevice', 0, type=int)


### PR DESCRIPTION
Reset where we save the KCC settings for the first time in over a decade since things have changed a lot. This is a fresh start anyone can jump into if their registry got weird between version differences.

Makes sense to do since we changed gui library. This way old versions won't break after using a new version just in case.

- temporary fix #663 
- related #523
- related #655