### PR TITLE
fix Error: image file is truncated

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -21,7 +21,6 @@
 import os
 import pathlib
 import re
-import subprocess
 import sys
 from argparse import ArgumentParser
 from time import strftime, gmtime
@@ -36,7 +35,7 @@ from multiprocessing import Pool
 from uuid import uuid4
 from natsort import os_sorted
 from slugify import slugify as slugify_ext
-from PIL import Image
+from PIL import Image, ImageFile
 from subprocess import STDOUT, PIPE
 from psutil import virtual_memory, disk_usage
 from html import escape as hescape
@@ -50,6 +49,8 @@ from . import dualmetafix
 from . import metadata
 from . import kindle
 from . import __version__
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 def main(argv=None):


### PR DESCRIPTION
This lets us handle corrupted files gracefully. (Bottom of image is corrupted.)
![page_117](https://github.com/ciromattia/kcc/assets/20757319/be072b50-8bf4-4d1b-8182-1cf83b9169c2)

```
Error during conversion...:

Image file ...page_117.jpg is corrupted. Error: image file is truncated (6 bytes not processed)

Traceback:
File "kindlecomicconverter/KCC_gui.py", line 289, in run
File "kindlecomicconverter/comic2ebook.py", line 1146, in makeBook
File "kindlecomicconverter/comic2ebook.py", line 887, in detectCorruption

```
https://stackoverflow.com/questions/12984426/pil-ioerror-image-file-truncated-with-big-images