### PR TITLE
Kindle Scribe 1860 max width

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1098,10 +1098,6 @@ def checkOptions(options):
         image.ProfileData.Profiles["Custom"] = newProfile
         options.profile = "Custom"
     options.profileData = image.ProfileData.Profiles[options.profile]
-    # kindle scribe conversion to mobi is limited in resolution by kindlegen, same with send to kindle and epub
-    if options.profile == 'KS' and (options.format == 'MOBI' or options.format == 'EPUB'):
-        options.profileData = list(options.profileData)
-        options.profileData[1] = (1440, 1920)
     return options
 
 

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -308,6 +308,7 @@ class ComicPage:
         self.image = self.image.quantize(palette=palImg)
 
     def resizeImage(self):
+        # kindlegen max height is 1920
         ratio_device = float(self.size[1]) / float(self.size[0])
         ratio_image = float(self.image.size[1]) / float(self.image.size[0])
         method = self.resize_method()
@@ -322,18 +323,26 @@ class ComicPage:
                     self.image = ImageOps.fit(self.image, self.size, method=method)
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
+                if self.opt.profileData[0] == 'Kindle Scribe':
+                    self.size = (1440, 1920)
                 self.image = ImageOps.fit(self.image, self.size, method=method)
             elif self.opt.format == 'CBZ' or self.opt.kfx:
                 self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
             else:
+                if self.opt.profileData[0] == 'Kindle Scribe':
+                    self.size = (1860, 1920)
                 self.image = ImageOps.contain(self.image, self.size, method=method)
 
     def resize_method(self):
+        if self.opt.profileData[0] == 'Kindle Scribe':
+            if self.image.size[0] <= 1440 and self.image.size[1] <= 1920:
+                return Image.Resampling.BICUBIC
+            else:
+                return Image.Resampling.LANCZOS
         if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:
-            method = Image.Resampling.BICUBIC
+            return Image.Resampling.BICUBIC
         else:
-            method = Image.Resampling.LANCZOS
-        return method
+            return Image.Resampling.LANCZOS
 
     def getBoundingBox(self, tmptmg):
         min_margin = [int(0.005 * i + 0.5) for i in tmptmg.size]

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -309,7 +309,9 @@ class ComicPage:
         self.image = self.image.quantize(palette=palImg)
 
     def resizeImage(self):
-        # kindlegen max height is 1920
+        # kindle scribe conversion to mobi is limited in resolution by kindlegen, same with send to kindle and epub
+        if self.kindle_scribe_azw3:
+            self.size = (1440, 1920)
         ratio_device = float(self.size[1]) / float(self.size[0])
         ratio_image = float(self.image.size[1]) / float(self.image.size[0])
         method = self.resize_method()
@@ -324,22 +326,15 @@ class ComicPage:
                     self.image = ImageOps.fit(self.image, self.size, method=method)
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
-                if self.kindle_scribe_azw3:
-                    self.size = (1440, 1920)
                 self.image = ImageOps.fit(self.image, self.size, method=method)
             elif self.opt.format == 'CBZ' or self.opt.kfx:
                 self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
             else:
                 if self.kindle_scribe_azw3:
-                    self.size = (1860, 1920)
+                    self.size[0] = 1860
                 self.image = ImageOps.contain(self.image, self.size, method=method)
 
     def resize_method(self):
-        if self.kindle_scribe_azw3:
-            if self.image.size[0] <= 1440 and self.image.size[1] <= 1920:
-                return Image.Resampling.BICUBIC
-            else:
-                return Image.Resampling.LANCZOS
         if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:
             return Image.Resampling.BICUBIC
         else:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -239,6 +239,7 @@ class ComicPage:
         _, self.size, self.palette, self.gamma = self.opt.profileData
         if self.opt.hq:
             self.size = (int(self.size[0] * 1.5), int(self.size[1] * 1.5))
+        self.kindle_scribe_azw3 = (options.profile == 'KS') and (options.format in ('MOBI', 'EPUB'))
         self.image = image
         self.color = color
         self.fill = fill
@@ -323,18 +324,18 @@ class ComicPage:
                     self.image = ImageOps.fit(self.image, self.size, method=method)
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
-                if self.opt.profileData[0] == 'Kindle Scribe':
+                if self.kindle_scribe_azw3:
                     self.size = (1440, 1920)
                 self.image = ImageOps.fit(self.image, self.size, method=method)
             elif self.opt.format == 'CBZ' or self.opt.kfx:
                 self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
             else:
-                if self.opt.profileData[0] == 'Kindle Scribe':
+                if self.kindle_scribe_azw3:
                     self.size = (1860, 1920)
                 self.image = ImageOps.contain(self.image, self.size, method=method)
 
     def resize_method(self):
-        if self.opt.profileData[0] == 'Kindle Scribe':
+        if self.kindle_scribe_azw3:
             if self.image.size[0] <= 1440 and self.image.size[1] <= 1920:
                 return Image.Resampling.BICUBIC
             else:


### PR DESCRIPTION
If you have a square page, kindlegen will allow a really sharp 1860x1860 image. Much better than prior 1440x1440.

* related #460 

But ideally we could figure out if kindlegen has a hidden arg that doesn't resize...