### PR TITLE
reduce dependency on 7z, unar, homebrew by using builtin tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You'll need to install various tools to access important but optional features. 
 
 ### 7-Zip
 
-Required if you are using an older Windows version <2018.
+Required if you are using an older Windows version (~2018).
 
 Optional otherwise for metadata editing.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You'll need to install various tools to access important but optional features. 
 
 ### 7-Zip
 
-Required if you are using an older Windows version (~2018).
+Required if you are using an older Windows version <2018.
 
 Optional otherwise for metadata editing.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You'll need to install various tools to access important but optional features. 
 
 ### 7-Zip
 
+Required if you are using an older Windows version (~2018).
+
+Optional otherwise for metadata editing.
+
 #### Windows 7-Zip
 
 First install the `64-bit x64` version of 7z from https://www.7-zip.org/ or with command line:

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ You'll need to install various tools to access important but optional features. 
 
 ### 7-Zip
 
-Required if you are using an older Windows version (~2018).
-
-Optional otherwise for metadata editing.
-
 #### Windows 7-Zip
 
 First install the `64-bit x64` version of 7z from https://www.7-zip.org/ or with command line:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ KCC expects `7z` to be installed to the default location at `C:\Program Files\7-
 with [Homebrew](https://brew.sh/) installed
 ```
 brew install p7zip
+brew install unar
 ```
 
 ### KindleGen

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ KCC expects `7z` to be installed to the default location at `C:\Program Files\7-
 with [Homebrew](https://brew.sh/) installed
 ```
 brew install p7zip
-brew install unar
 ```
 
 ### KindleGen

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -492,6 +492,8 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             else:
                 fname = ['']
                 self.showDialog("Editor is disabled due to a lack of 7z.", 'error')
+                self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
+                ' to enable metadata editing.', 'warning')
             if fname[0] != '':
                 if sys.platform.startswith('win'):
                     sname = fname[0].replace('/', '\\')

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -462,7 +462,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         if self.needClean:
             self.needClean = False
             GUI.jobList.clear()
-        if self.sevenzip:
+        if self.tar or self.sevenzip:
             fnames = QtWidgets.QFileDialog.getOpenFileNames(MW, 'Select file', self.lastPath,
                                                             'Comic (*.cbz *.cbr *.cb7 *.zip *.rar *.7z *.pdf);;All (*.*)')
         else:
@@ -802,7 +802,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                 self.needClean = False
                 GUI.jobList.clear()
             formats = ['.pdf']
-            if self.sevenzip:
+            if self.tar or self.sevenzip:
                 formats.extend(['.cb7', '.7z', '.cbz', '.zip', '.cbr', '.rar'])
             if os.path.isdir(message):
                 GUI.jobList.addItem(message)
@@ -1029,12 +1029,18 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                             '<a href="https://github.com/ciromattia/kcc/wiki/Important-tips">important tips</a>.',
                             'info')
         try:
+            subprocess_run_silent(['tar'], stdout=PIPE, stderr=STDOUT)
+            self.tar = True
+        except FileNotFoundError:
+            self.tar = False
+        try:
             subprocess_run_silent(['7z'], stdout=PIPE, stderr=STDOUT)
             self.sevenzip = True
         except FileNotFoundError:
             self.sevenzip = False
-            self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
-                            ' to enable CBZ/CBR/ZIP/etc processing.', 'warning')
+            if not self.tar:
+                self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
+                                ' to enable CBZ/CBR/ZIP/etc processing.', 'warning')
         self.detectKindleGen(True)
 
         APP.messageFromOtherInstance.connect(self.handleMessage)

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -644,6 +644,9 @@ def getWorkFolder(afile):
             try:
                 cbx = comicarchive.ComicArchive(afile)
                 path = cbx.extract(workdir)
+                tdir = os.listdir(workdir)
+                if 'ComicInfo.xml' in tdir:
+                    tdir.remove('ComicInfo.xml')        
             except OSError as e:
                 rmtree(workdir, True)
                 raise UserWarning(e)

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -70,9 +70,6 @@ class ComicArchive:
                     , stdout=PIPE, stderr=STDOUT)
             if process.returncode != 0:
                 raise OSError(EXTRACTION_ERROR)
-        elif process.returncode != 0 and platform.system() == 'Darwin':
-            process = subprocess_run_silent(['unar', self.filepath, '-f', '-o', targetdir], 
-                stdout=PIPE, stderr=STDOUT)
         elif process.returncode != 0:
             raise OSError(EXTRACTION_ERROR)
         return targetdir

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -70,6 +70,9 @@ class ComicArchive:
                     , stdout=PIPE, stderr=STDOUT)
             if process.returncode != 0:
                 raise OSError(EXTRACTION_ERROR)
+        elif process.returncode != 0 and platform.system() == 'Darwin':
+            process = subprocess_run_silent(['unar', self.filepath, '-f', '-o', targetdir], 
+                stdout=PIPE, stderr=STDOUT)
         elif process.returncode != 0:
             raise OSError(EXTRACTION_ERROR)
         return targetdir


### PR DESCRIPTION
tar is an incredibly powerful decompression tool that even supports rar.

It was always been in macOS. And was added to Windows 10 in 2018. It's probably in every linux distro.

https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/

This way, users don't need to install homebrew and xcode on macOS to use it unless they also want metadata editing. Same for Windows.

Also, tar seems faster than 7z!

Test builds: https://github.com/axu2/kcc/releases/tag/v6.0.0-tar

![image](https://github.com/ciromattia/kcc/assets/20757319/83f1cdeb-c04a-4104-8018-84e083272d95)

@AlicesReflexion @cookie99999 @darodi Do you think unrar is still needed on fedora?

Related:

- #370 
- #512 
- #515 
- #625 

Feel free to test: @thevenomsnake @shihong5858 @AdrianJesusSilva