### PR TITLE
search for kindlegen in %UserProfile%

### DIFF
--- a/kcc.py
+++ b/kcc.py
@@ -50,6 +50,7 @@ elif sys.platform.startswith('win'):
     win_paths = [
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\KC2'),
         os.path.expandvars('%LOCALAPPDATA%\\Amazon\\Kindle Previewer 3\\lib\\fc\\bin\\'),
+        os.path.expandvars('%UserProfile%\\Kindle Previewer 3\\lib\\fc\\bin\\'),
         'C:\\Apps\\Kindle Previewer 3\\lib\\fc\\bin',
         'D:\\Apps\\Kindle Previewer 3\\lib\\fc\\bin',
         'E:\\Apps\\Kindle Previewer 3\\lib\\fc\\bin',


### PR DESCRIPTION
- fix #721 

@ranart4 

Can you see if this build can be run without putting it in a special place?

https://github.com/axu2/kcc/releases/tag/v6.1.0-user-profile

Can you tell me if kindlegen is at this location? I modified kcc to look there. 

`%UserProfile%\Kindle Previewer 3\lib\fc\bin\`