### PR TITLE
Added Calibre HTML output cbz support

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -808,6 +808,26 @@ def sanitizePermissions(filetree):
             os.chmod(os.path.join(root, name), S_IWRITE | S_IREAD | S_IEXEC)
 
 
+def detectCalibreHTML(path):
+    if os.path.isdir(path):
+        for root, _, files in os.walk(path):
+            if len(files) == 1 and files[0].endswith('.html'):
+                htmlFile = os.path.join(root, files[0])
+                htmlFolder = os.path.join(root, files[0].replace('.html', '_files'))
+                if os.path.isdir(htmlFolder):
+                    imagesFolder = os.path.join(htmlFolder, 'OPS', 'images')
+                    if os.path.isdir(imagesFolder):
+                        cover = os.path.join(htmlFolder, 'cover.jpeg')
+                        if os.path.exists(cover):
+                            os.remove(htmlFile)
+                            for f in os.listdir(imagesFolder):
+                                move(os.path.join(imagesFolder, f), root)
+                            move(cover, os.path.join(root, '0000.jpg'))
+                            rmtree(htmlFolder)
+                            return True
+    return False
+
+
 def splitDirectory(path):
     level = -1
     for root, _, files in os.walk(os.path.join(path, 'OEBPS', 'Images')):
@@ -1155,6 +1175,7 @@ def makeBook(source, qtgui=None):
     print("Preparing source images...")
     path = getWorkFolder(source)
     print("Checking images...")
+    detectCalibreHTML(path)
     getComicInfo(os.path.join(path, "OEBPS", "Images"), source)
     detectCorruption(os.path.join(path, "OEBPS", "Images"), source)
     if options.webtoon:

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -816,12 +816,22 @@ def detectCalibreHTML(path):
                 htmlFolder = os.path.join(root, files[0].replace('.html', '_files'))
                 if os.path.isdir(htmlFolder):
                     imagesFolder = os.path.join(htmlFolder, 'OPS', 'images')
+                    imagesFolderNoOPS = os.path.join(htmlFolder, 'images')
                     if os.path.isdir(imagesFolder):
                         cover = os.path.join(htmlFolder, 'cover.jpeg')
                         if os.path.exists(cover):
                             os.remove(htmlFile)
                             for f in os.listdir(imagesFolder):
                                 move(os.path.join(imagesFolder, f), root)
+                            move(cover, os.path.join(root, '0000.jpg'))
+                            rmtree(htmlFolder)
+                            return True
+                    elif os.path.isdir(imagesFolderNoOPS):
+                        cover = os.path.join(htmlFolder, 'cover.jpeg')
+                        if os.path.exists(cover):
+                            os.remove(htmlFile)
+                            for f in os.listdir(imagesFolderNoOPS):
+                                move(os.path.join(imagesFolderNoOPS, f), root)
                             move(cover, os.path.join(root, '0000.jpg'))
                             rmtree(htmlFolder)
                             return True


### PR DESCRIPTION
Ensured the check for Calibre HTML export is non destructive and won't impact the rest of the code.

I had a bunch of CBZ that were basically wrapping the Calibre HTML export in a cbz file. Added support to extract the images and place the cover at the top to then ensure proper function of the rest of the conversion process. If it's not a calibre HTML format (contains only an HTML file with a random identifier and a folder called RANDOMID_files) this update will not touch anything.