### PR TITLE
Replaced StrictVersion with packaging.version.parse for Python 3.12 compatibility

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -31,7 +31,7 @@ from PySide6.QtCore import Qt
 from xml.sax.saxutils import escape
 from psutil import Process
 from copy import copy
-from distutils.version import StrictVersion
+from packaging import version
 from raven import Client
 from tempfile import gettempdir
 
@@ -146,9 +146,9 @@ class VersionThread(QtCore.QThread):
             latest_version = json_parser["tag_name"]
             latest_version = re.sub(r'^v', "", latest_version)
 
-            if ("b" not in __version__ and StrictVersion(latest_version) > StrictVersion(__version__)) \
+            if ("b" not in __version__ and version.parse(latest_version) > version.parse(__version__)) \
                     or ("b" in __version__
-                        and StrictVersion(latest_version) >= StrictVersion(re.sub(r'b.*', '', __version__))):
+                        and version.parse(latest_version) >= version.parse(re.sub(r'b.*', '', __version__))):
                 MW.addMessage.emit('<a href="' + html_url + '"><b>The new version is available!</b></a>', 'warning',
                                    False)
         except Exception:
@@ -851,7 +851,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             for line in versionCheck.stdout.splitlines():
                 if 'Amazon kindlegen' in line:
                     versionCheck = line.split('V')[1].split(' ')[0]
-                    if StrictVersion(versionCheck) < StrictVersion('2.9'):
+                    if version.parse(versionCheck) < version.parse('2.9'):
                         self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
                                         ' is outdated! MOBI conversion might fail.', 'warning')
                     break

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -22,7 +22,7 @@ import os
 from hashlib import md5
 from html.parser import HTMLParser
 import subprocess
-from distutils.version import StrictVersion
+from packaging import version
 from re import split
 import sys
 from traceback import format_tb
@@ -103,7 +103,7 @@ def dependencyCheck(level):
     if level > 2:
         try:
             from PySide6.QtCore import qVersion as qtVersion
-            if StrictVersion('6.5.1') > StrictVersion(qtVersion()):
+            if version.parse('6.5.1') > version.parse(qtVersion()):
                 missing.append('PySide 6.5.1+')
         except ImportError:
             missing.append('PySide 6.5.1+')
@@ -114,7 +114,7 @@ def dependencyCheck(level):
     if level > 1:
         try:
             from psutil import __version__ as psutilVersion
-            if StrictVersion('5.0.0') > StrictVersion(psutilVersion):
+            if version.parse('5.0.0') > version.parse(psutilVersion):
                 missing.append('psutil 5.0.0+')
         except ImportError:
             missing.append('psutil 5.0.0+')
@@ -123,13 +123,13 @@ def dependencyCheck(level):
             from slugify import __version__ as slugifyVersion
             if isinstance(slugifyVersion, ModuleType):
                 slugifyVersion = slugifyVersion.__version__
-            if StrictVersion('1.2.1') > StrictVersion(slugifyVersion):
+            if version.parse('1.2.1') > version.parse(slugifyVersion):
                 missing.append('python-slugify 1.2.1+')
         except ImportError:
             missing.append('python-slugify 1.2.1+')
     try:
         from PIL import __version__ as pillowVersion
-        if StrictVersion('5.2.0') > StrictVersion(pillowVersion):
+        if version.parse('5.2.0') > version.parse(pillowVersion):
             missing.append('Pillow 5.2.0+')
     except ImportError:
         missing.append('Pillow 5.2.0+')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ raven>=6.0.0
 mozjpeg-lossless-optimization>=1.1.2
 natsort[fast]>=8.4.0
 distro>=1.8.0
+packaging==24.1
+


### PR DESCRIPTION
Simple drop-in replacement for the `distutils.StrictVersion`. Should partly 

- fix #618.