### PR TITLE
fix no such file or directory 7z

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -35,7 +35,7 @@ from distutils.version import StrictVersion
 from raven import Client
 from tempfile import gettempdir
 
-from .shared import HTMLStripper, sanitizeTrace, walkLevel, subprocess_run_silent
+from .shared import HTMLStripper, sanitizeTrace, walkLevel, subprocess_run
 from . import __version__
 from . import comic2ebook
 from . import metadata
@@ -846,7 +846,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             except Exception:
                 pass
         try:
-            versionCheck = subprocess_run_silent(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
+            versionCheck = subprocess_run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
             self.kindleGen = True
             for line in versionCheck.stdout.splitlines():
                 if 'Amazon kindlegen' in line:
@@ -1041,12 +1041,12 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                             '<a href="https://github.com/ciromattia/kcc/wiki/Important-tips">important tips</a>.',
                             'info')
         try:
-            subprocess_run_silent(['tar'], stdout=PIPE, stderr=STDOUT)
+            subprocess_run(['tar'], stdout=PIPE, stderr=STDOUT)
             self.tar = True
         except FileNotFoundError:
             self.tar = False
         try:
-            subprocess_run_silent(['7z'], stdout=PIPE, stderr=STDOUT)
+            subprocess_run(['7z'], stdout=PIPE, stderr=STDOUT)
             self.sevenzip = True
         except FileNotFoundError:
             self.sevenzip = False

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -40,7 +40,7 @@ from subprocess import STDOUT, PIPE
 from psutil import virtual_memory, disk_usage
 from html import escape as hescape
 
-from .shared import md5Checksum, getImageFileName, walkSort, walkLevel, sanitizeTrace, subprocess_run_silent
+from .shared import md5Checksum, getImageFileName, walkSort, walkLevel, sanitizeTrace, subprocess_run
 from . import comic2panel
 from . import image
 from . import comicarchive
@@ -1114,13 +1114,13 @@ def checkTools(source):
     if source.endswith('.CB7') or source.endswith('.7Z') or source.endswith('.RAR') or source.endswith('.CBR') or \
             source.endswith('.ZIP') or source.endswith('.CBZ'):
         try:
-            subprocess_run_silent(['7z'], stdout=PIPE, stderr=STDOUT)
+            subprocess_run(['7z'], stdout=PIPE, stderr=STDOUT)
         except FileNotFoundError:
             print('ERROR: 7z is missing!')
             sys.exit(1)
     if options.format == 'MOBI':
         try:
-            subprocess_run_silent(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT)
+            subprocess_run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT)
         except FileNotFoundError:
             print('ERROR: KindleGen is missing!')
             sys.exit(1)
@@ -1277,7 +1277,7 @@ def makeMOBIWorker(item):
     kindlegenError = ''
     try:
         if os.path.getsize(item) < 629145600:
-            output = subprocess_run_silent(['kindlegen', '-dont_append_source', '-locale', 'en', item],
+            output = subprocess_run(['kindlegen', '-dont_append_source', '-locale', 'en', item],
                            stdout=PIPE, stderr=STDOUT, encoding='UTF-8')
             for line in output.stdout.splitlines():
                 # ERROR: Generic error

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -52,9 +52,7 @@ class ComicArchive:
                 for line in process.stdout.splitlines():
                     if b'Type =' in line:
                         return line.rstrip().decode().split(' = ')[1].upper()
-            except FileNotFoundError:
-                pass
-            except CalledProcessError:
+            except (FileNotFoundError, CalledProcessError):
                 pass
 
         raise OSError(EXTRACTION_ERROR)
@@ -67,7 +65,6 @@ class ComicArchive:
             ['tar', '-xf', self.filepath, '-C', targetdir],
             ['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
         ]
-        missing = []
 
         if distro.id() == 'fedora':
             extraction_commands.append(
@@ -78,15 +75,10 @@ class ComicArchive:
             try:
                 subprocess_run(cmd, capture_output=True, check=True)
                 return targetdir
-            except FileNotFoundError:
-                missing.append(cmd[0])
-            except CalledProcessError:
+            except (FileNotFoundError, CalledProcessError):
                 pass
-        
-        if missing:
-            raise OSError(f'Extraction failed, try downloading {missing}')
-        else:
-            raise OSError(EXTRACTION_ERROR)
+
+        raise OSError(EXTRACTION_ERROR)
 
     def addFile(self, sourcefile):
         if self.type in ['RAR', 'RAR5']:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -67,7 +67,7 @@ class ComicArchive:
         missing = []
 
         extraction_commands = [
-            ['tard', '-xf', self.filepath, '-C', targetdir],
+            ['tar', '-xf', self.filepath, '-C', targetdir],
             ['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
         ]
 
@@ -91,7 +91,7 @@ class ComicArchive:
                 pass
         
         if missing:
-            raise OSError(f'Extraction failed, try downloading <a href="https://github.com/ciromattia/kcc#7-zip">additional extraction software.</a>  ')
+            raise OSError(f'Extraction failed, download <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')
         else:
             raise OSError(EXTRACTION_ERROR)
 

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -20,6 +20,7 @@
 
 from functools import cached_property
 import os
+import platform
 import distro
 from subprocess import STDOUT, PIPE, CalledProcessError
 from xml.dom.minidom import parseString
@@ -63,11 +64,17 @@ class ComicArchive:
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
 
+        missing = []
+
         extraction_commands = [
-            ['tar', '-xf', self.filepath, '-C', targetdir],
+            ['tard', '-xf', self.filepath, '-C', targetdir],
             ['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
         ]
-        missing = []
+
+        if platform.system() == 'Darwin':
+            extraction_commands.append(
+                ['unar', self.filepath, '-f', '-o', targetdir]
+            )
 
         if distro.id() == 'fedora':
             extraction_commands.append(
@@ -84,7 +91,7 @@ class ComicArchive:
                 pass
         
         if missing:
-            raise OSError(f'Extraction failed, try downloading {missing}')
+            raise OSError(f'Extraction failed, try downloading <a href="https://github.com/ciromattia/kcc#7-zip">additional extraction software.</a>  ')
         else:
             raise OSError(EXTRACTION_ERROR)
 

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -91,7 +91,7 @@ class ComicArchive:
                 pass
         
         if missing:
-            raise OSError(f'Extraction failed, download <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')
+            raise OSError(f'Extraction failed, install <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')
         else:
             raise OSError(EXTRACTION_ERROR)
 

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -52,7 +52,9 @@ class ComicArchive:
                 for line in process.stdout.splitlines():
                     if b'Type =' in line:
                         return line.rstrip().decode().split(' = ')[1].upper()
-            except (FileNotFoundError, CalledProcessError):
+            except FileNotFoundError:
+                pass
+            except CalledProcessError:
                 pass
 
         raise OSError(EXTRACTION_ERROR)
@@ -65,6 +67,7 @@ class ComicArchive:
             ['tar', '-xf', self.filepath, '-C', targetdir],
             ['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
         ]
+        missing = []
 
         if distro.id() == 'fedora':
             extraction_commands.append(
@@ -75,10 +78,15 @@ class ComicArchive:
             try:
                 subprocess_run(cmd, capture_output=True, check=True)
                 return targetdir
-            except (FileNotFoundError, CalledProcessError):
+            except FileNotFoundError:
+                missing.append(cmd[0])
+            except CalledProcessError:
                 pass
-
-        raise OSError(EXTRACTION_ERROR)
+        
+        if missing:
+            raise OSError(f'Extraction failed, try downloading {missing}')
+        else:
+            raise OSError(EXTRACTION_ERROR)
 
     def addFile(self, sourcefile):
         if self.type in ['RAR', 'RAR5']:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -18,15 +18,13 @@
 # PERFORMANCE OF THIS SOFTWARE.
 #
 
+from functools import cached_property
 import os
-import platform
-import subprocess
 import distro
-from shutil import move
 from subprocess import STDOUT, PIPE, CalledProcessError
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
-from .shared import subprocess_run_silent
+from .shared import subprocess_run
 
 EXTRACTION_ERROR = 'Failed to extract archive. Try extracting file outside of KCC.'
 
@@ -34,56 +32,72 @@ EXTRACTION_ERROR = 'Failed to extract archive. Try extracting file outside of KC
 class ComicArchive:
     def __init__(self, filepath):
         self.filepath = filepath
-        self.type = None
         if not os.path.isfile(self.filepath):
             raise OSError('File not found.')
-        try:
-            process = subprocess_run_silent(['7z', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE)
-        except FileNotFoundError:
-            return
-        for line in process.stdout.splitlines():
-            if b'Type =' in line:
-                self.type = line.rstrip().decode().split(' = ')[1].upper()
-                break
-        if process.returncode != 0 and distro.id() == 'fedora':
-            process = subprocess_run_silent(['unrar', 'l', '-y', '-p1', self.filepath], stderr=STDOUT, stdout=PIPE)
-            for line in process.stdout.splitlines():
-                if b'Details: ' in line:
-                    self.type = line.rstrip().decode().split(' ')[1].upper()
-                    break
-            if process.returncode != 0:
-                raise OSError(EXTRACTION_ERROR)
+
+    @cached_property
+    def type(self):    
+        extraction_commands = [
+            ['7z', 'l', '-y', '-p1', self.filepath],
+        ]
+
+        if distro.id() == 'fedora':
+            extraction_commands.append(
+                ['unrar', 'l', '-y', '-p1', self.filepath],
+            )
+
+        for cmd in extraction_commands:
+            try:
+                process = subprocess_run(cmd, capture_output=True, check=True)
+                for line in process.stdout.splitlines():
+                    if b'Type =' in line:
+                        return line.rstrip().decode().split(' = ')[1].upper()
+            except FileNotFoundError:
+                pass
+            except CalledProcessError:
+                pass
+
+        raise OSError(EXTRACTION_ERROR)
 
     def extract(self, targetdir):
         if not os.path.isdir(targetdir):
             raise OSError('Target directory doesn\'t exist.')
-        try:
-            process = subprocess_run_silent(['tar', '-xf', self.filepath, '-C', targetdir], 
-                                            stdout=PIPE, stderr=STDOUT, check=True)
-            return targetdir
-        except (FileNotFoundError, CalledProcessError):
-            pass
-        process = subprocess_run_silent(['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
-                                 stdout=PIPE, stderr=STDOUT)
-        if process.returncode != 0 and distro.id() == 'fedora':
-            process = subprocess_run_silent(['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir] 
-                    , stdout=PIPE, stderr=STDOUT)
-            if process.returncode != 0:
-                raise OSError(EXTRACTION_ERROR)
-        elif process.returncode != 0:
+
+        extraction_commands = [
+            ['tar', '-xf', self.filepath, '-C', targetdir],
+            ['7z', 'x', '-y', '-xr!__MACOSX', '-xr!.DS_Store', '-xr!thumbs.db', '-xr!Thumbs.db', '-o' + targetdir, self.filepath],
+        ]
+        missing = []
+
+        if distro.id() == 'fedora':
+            extraction_commands.append(
+                ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir]
+            )
+        
+        for cmd in extraction_commands:
+            try:
+                subprocess_run(cmd, capture_output=True, check=True)
+                return targetdir
+            except FileNotFoundError:
+                missing.append(cmd[0])
+            except CalledProcessError:
+                pass
+        
+        if missing:
+            raise OSError(f'Extraction failed, try downloading {missing}')
+        else:
             raise OSError(EXTRACTION_ERROR)
-        return targetdir
 
     def addFile(self, sourcefile):
         if self.type in ['RAR', 'RAR5']:
             raise NotImplementedError
-        process = subprocess_run_silent(['7z', 'a', '-y', self.filepath, sourcefile],
+        process = subprocess_run(['7z', 'a', '-y', self.filepath, sourcefile],
                         stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0:
             raise OSError('Failed to add the file.')
 
     def extractMetadata(self):
-        process = subprocess_run_silent(['7z', 'x', '-y', '-so', self.filepath, 'ComicInfo.xml'],
+        process = subprocess_run(['7z', 'x', '-y', '-so', self.filepath, 'ComicInfo.xml'],
                         stdout=PIPE, stderr=STDOUT)
         if process.returncode != 0:
             raise OSError(EXTRACTION_ERROR)

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -137,7 +137,7 @@ def dependencyCheck(level):
         print('ERROR: ' + ', '.join(missing) + ' is not installed!')
         sys.exit(1)
 
-def subprocess_run_silent(command, **kwargs):
+def subprocess_run(command, **kwargs):
     if (os.name == 'nt'):
         kwargs.setdefault('creationflags', subprocess.CREATE_NO_WINDOW)
     return subprocess.run(command, **kwargs)


### PR DESCRIPTION
forgot to handle case where tar fails on corrupted file.

This gives a better error message if extraction fails for some reason, and less duplicated code.

- Fix #730 

![image](https://github.com/user-attachments/assets/586ddc63-847c-4d88-92cc-b113a5429ea3)
