### PR TITLE
fix Docker linux arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Select final stage based on TARGETARCH ARG
-FROM ghcr.io/ciromattia/kcc:docker-base-20230809
+FROM ghcr.io/ciromattia/kcc:docker-base-20240928
 LABEL com.kcc.name="Kindle Comic Converter"
 LABEL com.kcc.author="Ciro Mattia Gonano, Paweł Jastrzębski and Darodi"
 LABEL org.opencontainers.image.description='Kindle Comic Converter'

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -29,6 +29,7 @@ ENV LC_ALL=C.UTF-8 \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY requirements.txt /opt/kcc/
+ENV PATH="/opt/venv/bin:$PATH"
 
 RUN set -x && \
     TEMP_PACKAGES=() && \

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -64,9 +64,8 @@ RUN set -x && \
         && \
     # Install required python modules
     python -m pip install --upgrade pip && \
-#    python -m pip install -r /opt/kcc/requirements.txt && \
     python -m venv /opt/venv && \
-    python -m pip install --upgrade pillow python-slugify psutil raven mozjpeg-lossless-optimization
+    python -m pip install -r /opt/kcc/requirements.txt
 
 
 ######################################################################################

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -85,6 +85,9 @@ ENV LC_ALL=C.UTF-8 \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+COPY requirements.txt /opt/kcc/
+ENV PATH="/opt/venv/bin:$PATH"
+
 RUN set -x && \
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \
@@ -122,9 +125,8 @@ RUN set -x && \
         && \
     # Install required python modules
     python -m pip install --upgrade pip && \
-#    python -m pip install -r /opt/kcc/requirements.txt && \
     python -m venv /opt/venv && \
-    python -m pip install --upgrade pillow python-slugify psutil raven mozjpeg-lossless-optimization
+    python -m pip install -r /opt/kcc/requirements.txt
 
 
 ######################################################################################

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -28,6 +28,8 @@ ENV LC_ALL=C.UTF-8 \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+COPY requirements.txt /opt/kcc/
+
 RUN set -x && \
     TEMP_PACKAGES=() && \
     KEPT_PACKAGES=() && \

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -126,7 +126,7 @@ RUN set -x && \
     # Install required python modules
     python -m pip install --upgrade pip && \
     python -m venv /opt/venv && \
-    python -m pip install -r /opt/kcc/requirements.txt
+    python -m pip install Pillow psutil requests python-slugify raven packaging mozjpeg-lossless-optimization natsort[fast] distro
 
 
 ######################################################################################

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -126,7 +126,7 @@ RUN set -x && \
     # Install required python modules
     python -m pip install --upgrade pip && \
     python -m venv /opt/venv && \
-    python -m pip install Pillow psutil requests python-slugify raven packaging mozjpeg-lossless-optimization natsort[fast] distro
+    python -m pip install --upgrade pillow psutil requests python-slugify raven packaging mozjpeg-lossless-optimization natsort[fast] distro
 
 
 ######################################################################################

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -155,5 +155,5 @@ WORKDIR /app
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get -yq upgrade && \
     apt-get install -y p7zip-full unrar-free  && \
     ln -s /app/kindlegen /bin/kindlegen && \
-    echo docker-base-20230809 > /IMAGE_VERSION
+    echo docker-base-20240928 > /IMAGE_VERSION
 


### PR DESCRIPTION
- fix #634 
- fix #668

```
ENV PATH="/opt/venv/bin:$PATH"
```

activates the venv

pyside6 has a linux arm64 build, convenient!