### PR TITLE
Adds --nokepub parameter to kcc-c2e.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ MANDATORY:
 
 MAIN:
   -p PROFILE, --profile PROFILE
-                        Device profile (Available options: K1, K2, K34, K578, KDX, KPW, KPW5, KV, KO, K11, KS, KoMT, KoG, KoGHD, KoA, KoAHD, KoAH2O, KoAO, KoN, KoC, KoL, KoF, KoS, KoE) [Default=KV]
+                        Device profile (Available options: K1, K2, K34, K578, KDX, KPW, KPW5, KV, KO, K11, KS, KoMT, KoG, KoGHD, KoA, KoAHD, KoAH2O, KoAO, KoN, KoC, KoCC, KoL, KoLC, KoF, KoS, KoE)
+                        [Default=KV]
   -m, --manga-style     Manga style (right-to-left reading and splitting)
   -q, --hq              Try to increase the quality of magnification
   -2, --two-panel       Display two not four panels in Panel View mode
@@ -172,10 +173,14 @@ OUTPUT SETTINGS:
                         Output generated file to specified directory or file
   -t TITLE, --title TITLE
                         Comic title [Default=filename or directory name]
+  -a AUTHOR, --author AUTHOR
+                        Author name [Default=KCC]
   -f FORMAT, --format FORMAT
                         Output format (Available options: Auto, MOBI, EPUB, CBZ, KFX, MOBI+EPUB) [Default=Auto]
+  --nokepub             If format is EPUB, output file with '.epub' extension rather than '.kepub.epub'
   -b BATCHSPLIT, --batchsplit BATCHSPLIT
                         Split output into multiple files. 0: Don't split 1: Automatic mode 2: Consider every subdirectory as separate volume [Default=0]
+  --dedupecover         De-duplicate the cover as the first page in the book
 
 CUSTOM PROFILE:
   --customwidth CUSTOMWIDTH

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -666,7 +666,11 @@ def getOutputFilename(srcpath, wantedname, ext, tomenumber):
     if srcpath[-1] == os.path.sep:
         srcpath = srcpath[:-1]
     if 'Ko' in options.profile and options.format == 'EPUB':
-        ext = '.kepub.epub'
+        if options.noKepub:
+            # Just use normal epub extension if no_kepub option is true
+            ext = '.epub'
+        else:
+            ext = '.kepub.epub'
     if wantedname is not None:
         if wantedname.endswith(ext):
             filename = os.path.abspath(wantedname)
@@ -981,6 +985,8 @@ def makeParser():
     output_options.add_argument("-f", "--format", action="store", dest="format", default="Auto",
                                 help="Output format (Available options: Auto, MOBI, EPUB, CBZ, KFX, MOBI+EPUB) "
                                      "[Default=Auto]")
+    output_options.add_argument("--nokepub", action="store_true", dest="noKepub", default=False,
+                                help="If format is EPUB, output file with '.epub' extension rather than '.kepub.epub'")
     output_options.add_argument("-b", "--batchsplit", type=int, dest="batchsplit", default="0",
                                 help="Split output into multiple files. 0: Don't split 1: Automatic mode "
                                      "2: Consider every subdirectory as separate volume [Default=0]")


### PR DESCRIPTION
This adds a `--nokepub` parameter to `kcc-c2e.py`. My rationale for adding this is as follows:

- I use KCC in a docker container which is a simple script that watches a comic directory for new comics and then calls KCC to convert to EPUB so i can read on my Kobo reader.
- I use Komga to host my comics
- Komga has recently introduced kepubify to automatically convert epub --> kepub
- As this tool, before this pull request, outputs `.kepub.epub`, Komga / kepubify gets a bit confused and tries to do `.kepub.epub.kepub.epub` or something similarly foolish and just freaks out that it's not a valid extension (fair enough)

I think this tool is great and I'd love to have the flexibility of generating just epubs with this change :)