### PR TITLE
simplify cover upload on newer MTP based Kindles by replacing EBOK with PDOC

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -380,7 +380,7 @@ class WorkerThread(QtCore.QThread):
                                     except Exception:
                                         pass
                             MW.addMessage.emit('Processing MOBI files... <b>Done!</b>', 'info', True)
-                            k = kindle.Kindle()
+                            k = kindle.Kindle(options.profile)
                             if k.path and k.coverSupport:
                                 for item in outputPath:
                                     comic2ebook.options.covers[outputPath.index(item)][0].saveToKindle(

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1227,7 +1227,7 @@ def makeBook(source, qtgui=None):
                 print('Error: KindleGen failed to create MOBI!')
                 print(errors)
                 return filepath
-        k = kindle.Kindle()
+        k = kindle.Kindle(options.profile)
         if k.path and k.coverSupport:
             print("Kindle detected. Uploading covers...")
         for i in filepath:
@@ -1249,12 +1249,13 @@ def makeBook(source, qtgui=None):
 
 
 def makeMOBIFix(item, uuid):
+    is_pdoc = options.profile in image.ProfileData.ProfilesKindlePDOC.keys()
     if not options.keep_epub:
         os.remove(item)
     mobiPath = item.replace('.epub', '.mobi')
     move(mobiPath, mobiPath + '_toclean')
     try:
-        dualmetafix.DualMobiMetaFix(mobiPath + '_toclean', mobiPath, bytes(uuid, 'UTF-8'))
+        dualmetafix.DualMobiMetaFix(mobiPath + '_toclean', mobiPath, bytes(uuid, 'UTF-8'), is_pdoc)
         return [True]
     except Exception as err:
         return [False, format(err)]

--- a/kindlecomicconverter/dualmetafix.py
+++ b/kindlecomicconverter/dualmetafix.py
@@ -147,7 +147,7 @@ class DualMobiMetaFix:
         rec0 = self.datain_rec0
         rec0 = del_exth(rec0, 501)
         rec0 = del_exth(rec0, 113)
-        rec0 = add_exth(rec0, 501, b'EBOK')
+        rec0 = add_exth(rec0, 501, b'PDOC')
         rec0 = add_exth(rec0, 113, asin)
         replacesection(self.datain, 0, rec0)
 
@@ -174,7 +174,7 @@ class DualMobiMetaFix:
         rec0 = self.datain_kfrec0
         rec0 = del_exth(rec0, 501)
         rec0 = del_exth(rec0, 113)
-        rec0 = add_exth(rec0, 501, b'EBOK')
+        rec0 = add_exth(rec0, 501, b'PDOC')
         rec0 = add_exth(rec0, 113, asin)
         replacesection(self.datain, datain_kf8, rec0)
 

--- a/kindlecomicconverter/dualmetafix.py
+++ b/kindlecomicconverter/dualmetafix.py
@@ -136,7 +136,11 @@ def del_exth(rec0, exth_num):
 
 
 class DualMobiMetaFix:
-    def __init__(self, infile, outfile, asin):
+    def __init__(self, infile, outfile, asin, is_pdoc):
+        cdetype = b'EBOK'
+        if is_pdoc:
+            cdetype = b'PDOC'
+
         shutil.copyfile(infile, outfile)
         f = open(outfile, "r+b")
         self.datain = mmap.mmap(f.fileno(), 0)
@@ -147,7 +151,7 @@ class DualMobiMetaFix:
         rec0 = self.datain_rec0
         rec0 = del_exth(rec0, 501)
         rec0 = del_exth(rec0, 113)
-        rec0 = add_exth(rec0, 501, b'PDOC')
+        rec0 = add_exth(rec0, 501, cdetype)
         rec0 = add_exth(rec0, 113, asin)
         replacesection(self.datain, 0, rec0)
 
@@ -174,7 +178,7 @@ class DualMobiMetaFix:
         rec0 = self.datain_kfrec0
         rec0 = del_exth(rec0, 501)
         rec0 = del_exth(rec0, 113)
-        rec0 = add_exth(rec0, 501, b'PDOC')
+        rec0 = add_exth(rec0, 501, cdetype)
         rec0 = add_exth(rec0, 113, asin)
         replacesection(self.datain, datain_kf8, rec0)
 

--- a/kindlecomicconverter/kindle.py
+++ b/kindlecomicconverter/kindle.py
@@ -24,8 +24,8 @@ from . import image
 
 class Kindle:
     def __init__(self, profile):
-        self.path = self.findDevice()
         self.profile = profile
+        self.path = self.findDevice()
         if self.path:
             self.coverSupport = self.checkThumbnails()
         else:

--- a/kindlecomicconverter/kindle.py
+++ b/kindlecomicconverter/kindle.py
@@ -19,16 +19,21 @@
 import os.path
 import psutil
 
+from . import image
+
 
 class Kindle:
-    def __init__(self):
+    def __init__(self, profile):
         self.path = self.findDevice()
+        self.profile = profile
         if self.path:
             self.coverSupport = self.checkThumbnails()
         else:
             self.coverSupport = False
 
     def findDevice(self):
+        if self.profile in image.ProfileData.ProfilesKindlePDOC.keys():
+            return False
         for drive in reversed(psutil.disk_partitions(False)):
             if (drive[2] == 'FAT32' and drive[3] == 'rw,removable') or \
                (drive[2] in ('vfat', 'msdos', 'FAT', 'apfs') and 'rw' in drive[3]):


### PR DESCRIPTION
- fix #765 
- fix #685 
- fix #508 

- builds off #764

Test builds: 

~~https://github.com/axu2/kcc/releases/tag/v6.2.1-pdoc~~

~~https://github.com/axu2/kcc/releases/tag/v6.2.1-comicrack-pdoc~~

https://github.com/axu2/kcc/releases/tag/v6.3.0

The Kindle Colorsoft has been reported to not expose the system/thumbnails folder for covers, so here's a workaround and pre-built exe.

It just replaces EBOK tag with PDOC, so Kindle reads the cover directly from the file. Please test and tell me if it has issues.

Also, should I remove the ASIN tag?

And does anyone remember when pdoc covers started being read by Kindles? @Zappy86