### PR TITLE
Add additional check for differently named Fedora-based distros

### DIFF
--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -42,7 +42,7 @@ class ComicArchive:
             ['7z', 'l', '-y', '-p1', self.filepath],
         ]
 
-        if distro.id() == 'fedora':
+        if distro.id() == 'fedora' or distro.like() == 'fedora':
             extraction_commands.append(
                 ['unrar', 'l', '-y', '-p1', self.filepath],
             )
@@ -76,7 +76,7 @@ class ComicArchive:
                 ['unar', self.filepath, '-f', '-o', targetdir]
             )
 
-        if distro.id() == 'fedora':
+        if distro.id() == 'fedora' or distro.like() == 'fedora':
             extraction_commands.append(
                 ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir]
             )


### PR DESCRIPTION
Bazzite is Fedora-based but fails the `distro.id() == 'fedora'` check because `distro.id()` resolves to "bazzite." I added an additional check to include `distro.like() == 'fedora'` for situations like this.

This needs to be formatted as an or statement because plain Fedora resolves `distro.like()` as a null string.