### PR TITLE
Revert "build appimage on ubuntu-20.04 instead of 22.04"

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Reverts ciromattia/kcc#795

- fix #796 