### PR TITLE
remove fastnumbers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - python-slugify>=1.2.1
   - raven>=6.0.0
   - distro
-  - natsort[fast]>=8.4.0
+  - natsort>=8.4.0
   - pip
   - pip:
     - mozjpeg-lossless-optimization>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ python-slugify>=1.2.1
 raven>=6.0.0
 packaging>=23.2
 mozjpeg-lossless-optimization>=1.1.2
-natsort[fast]>=8.4.0
+natsort>=8.4.0
 distro>=1.8.0
 numpy>=1.22.4,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
         'raven>=6.0.0',
         'requests>=2.31.0',
         'mozjpeg-lossless-optimization>=1.1.2',
-        'natsort[fast]>=8.4.0',
+        'natsort>=8.4.0',
         'distro',
         'numpy>=1.22.4,<2.0.0'
     ],


### PR DESCRIPTION
fastnumbers is tricky to install on some platforms. @catsout 

And our size of ~200 strings to sort per file means this makes no difference in sorting time, sorting time is insignificant for kcc.