### PR TITLE
build appimage on ubuntu-22.04 instead of 24.04

### DIFF
--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Even though GitHub says `ubuntu-latest` currently refers to `ubuntu-22.04`, the build logs actually showed that it was building on `24.04` in some cases. This is probably why it wasn't running properly on older platforms.

So I will explicitly require 22.04. I tried 20.04 earlier and that caused segmentation fault issues that I don't really want to look into.

@jeffmcneill Please test the rebuild of 7.1.2 soon.