### PR TITLE
Kaleido 3 Rainbow Artifact Reduction

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -44,7 +44,7 @@ from . import metadata
 from . import kindle
 from . import KCC_ui
 from . import KCC_ui_editor
-
+from .image import DisplayTypeFromDeviceName
 
 class QApplicationMessaging(QApplication):
     messageFromOtherInstance = Signal(bytes)
@@ -185,7 +185,6 @@ class ProgressThread(QThread):
     def stop(self):
         self.running = False
 
-
 class WorkerThread(QThread):
     def __init__(self):
         QThread.__init__(self)
@@ -221,6 +220,7 @@ class WorkerThread(QThread):
         currentJobs = []
 
         options.profile = GUI.profiles[str(GUI.deviceBox.currentText())]['Label']
+        options.displayType = DisplayTypeFromDeviceName(str(GUI.deviceBox.currentText()))
         gui_current_format = GUI.formats[str(GUI.formatBox.currentText())]['format']
         options.format = gui_current_format
         if GUI.mangaBox.isChecked():

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -616,6 +616,7 @@ def imgFileProcessing(work):
                 img.cropInterPanelEmptySections("horizontal" if opt.interpanelcrop == 1 else "both")
             img.autocontrastImage()
             img.resizeImage()
+            img.optimizeForDisplay()
             if opt.forcepng and not opt.forcecolor:
                 img.quantizeImage()
             output.append(img.saveToDir())

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -352,7 +352,7 @@ class ComicPage:
 
     def optimizeForDisplay(self):
         if (self.opt.displayType == DisplayType.KALEIDO3_COLOR):
-            unsharpFilter = ImageFilter.UnsharpMask()
+            unsharpFilter = ImageFilter.UnsharpMask(radius=1, percent=75)
             self.image = self.image.filter(unsharpFilter)
             self.image = self.image.filter(ImageFilter.BoxBlur(1.0))
             self.image = self.image.filter(unsharpFilter)

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -351,8 +351,9 @@ class ComicPage:
         self.image = self.image.quantize(palette=palImg)
 
     def optimizeForDisplay(self):
-        if (self.opt.displayType == DisplayType.KALEIDO3_COLOR):
-            unsharpFilter = ImageFilter.UnsharpMask(radius=1, percent=75)
+        # Reduce rainbow artifacts for grayscale images by breaking up dither patterns that cause Moire interference with color filter array
+        if (self.opt.displayType == DisplayType.KALEIDO3_COLOR and not self.color):
+            unsharpFilter = ImageFilter.UnsharpMask(radius=1, percent=100)
             self.image = self.image.filter(unsharpFilter)
             self.image = self.image.filter(ImageFilter.BoxBlur(1.0))
             self.image = self.image.filter(unsharpFilter)


### PR DESCRIPTION
- fix #771 

The color filter array for Kaleido 3 color displays can sometimes interfere with the dither patterns used in manga for gray tones, causing rainbows to appear in those areas (essentially a form of moire artifacting). While there are more sophisticated solutions, this commit introduces the naive solution of breaking up the dither pattern through blurring the image to fix the rainbow moire.

- Introduced display type information (represented as an enum) to device profiles, determined based on device names.
- Introduced an 'optimizeForDisplay()' processing step to image file processing that happens after resizing (partly for performance but mostly for adjusting the actual displayed image). For devices with Kaleido 3 color displays, this applies unsharp->box blur->unsharp to the image in an attempt to break up the interference pattern without losing too much sharpness in the original image.