### PR TITLE
improve speed by reverting corrupt image detection refactor

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -890,8 +890,7 @@ def chunk_process(path, mode, parent):
                     firstTome = False
     return output
 
-
-def detectCorruption(tmppath, orgpath):
+def detectSuboptimalProcessing(tmppath, orgpath):
     imageNumber = 0
     imageSmaller = 0
     alreadyProcessed = False
@@ -907,9 +906,6 @@ def detectCorruption(tmppath, orgpath):
                     raise RuntimeError('Image file %s is corrupted.' % pathOrg)
                 try:
                     img = Image.open(path)
-                    img.verify()
-                    img = Image.open(path)
-                    img.load()
                     imageNumber += 1
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:
                         imageSmaller += 1
@@ -1181,7 +1177,7 @@ def makeBook(source, qtgui=None):
     path = getWorkFolder(source)
     print("Checking images...")
     getComicInfo(os.path.join(path, "OEBPS", "Images"), source)
-    detectCorruption(os.path.join(path, "OEBPS", "Images"), source)
+    detectSuboptimalProcessing(os.path.join(path, "OEBPS", "Images"), source)
     if options.webtoon:
         y = image.ProfileData.Profiles[options.profile][1][1]
         comic2panel.main(['-y ' + str(y), '-i', '-m', path], qtgui)

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -141,7 +141,13 @@ class ComicPageParser:
         self.source = source
         self.size = self.opt.profileData[1]
         self.payload = []
-        self.image = Image.open(os.path.join(source[0], source[1])).convert('RGB')
+
+        # Detect corruption in source image, let caller catch any exceptions triggered.
+        srcImgPath = os.path.join(source[0], source[1])
+        self.image = Image.open(srcImgPath)
+        self.image.verify()
+        self.image = Image.open(srcImgPath).convert('RGB')
+
         self.color = self.colorCheck()
         self.fill = self.fillCheck()
         # backwards compatibility for Pillow >9.1.0


### PR DESCRIPTION
@utopiafallen This was very useful when debugging an issue related to large files. Even with a very fast CPU (Apple M2), this sped things up a lot.

The progress bar updates have strange behavior on macOS however, I don't think I can merge those. Basically, on macOS, it doesn't show the format text ever.

I can confirm caller catches corrupt images appropriately.