### PR TITLE
improve speed by using renames instead of copytree+rmtree

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -672,8 +672,7 @@ def getWorkFolder(afile):
     else:
         raise UserWarning("Failed to open source file/directory.")
     newpath = mkdtemp('', 'KCC-', os.path.dirname(afile))
-    copytree(path, os.path.join(newpath, 'OEBPS', 'Images'))
-    rmtree(workdir, True)
+    os.renames(path, os.path.join(newpath, 'OEBPS', 'Images'))
     return newpath
 
 


### PR DESCRIPTION
Optimize getWorkFolder() to use directory renaming instead of copy + …
…delete

Way cheaper to just rename a directory into the destination than to copy and delete.

@utopiafallen Thanks again. I removed the perf_counters since it's no longer neccessary.