### PR TITLE
fix cannot identify image file by deprioritizng tar

### DIFF
--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -76,6 +76,8 @@ class ComicArchive:
                 ['unar', self.filepath, '-f', '-o', targetdir]
             )
 
+        extraction_commands.reverse()
+
         if distro.id() == 'fedora' or distro.like() == 'fedora':
             extraction_commands.append(
                 ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.filepath, targetdir]


### PR DESCRIPTION
`tar` actually can leave files in a weird state. So I'll make it the last priority.