### PR TITLE
Use 7z to save ~10 sec per epub/cbz compression over Python ZipFile

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -37,7 +37,7 @@ from packaging.version import Version
 from raven import Client
 from tempfile import gettempdir
 
-from .shared import HTMLStripper, sanitizeTrace, walkLevel, subprocess_run
+from .shared import HTMLStripper, available_archive_tools, sanitizeTrace, walkLevel, subprocess_run
 from . import __version__
 from . import comic2ebook
 from . import metadata
@@ -1066,19 +1066,12 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.addMessage('Since you are a new user of <b>KCC</b> please see few '
                             '<a href="https://github.com/ciromattia/kcc/wiki/Important-tips">important tips</a>.',
                             'info')
-        try:
-            subprocess_run(['tar'], stdout=PIPE, stderr=STDOUT)
-            self.tar = True
-        except FileNotFoundError:
-            self.tar = False
-        try:
-            subprocess_run(['7z'], stdout=PIPE, stderr=STDOUT)
-            self.sevenzip = True
-        except FileNotFoundError:
-            self.sevenzip = False
-            if not self.tar:
-                self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
-                                ' to enable CBZ/CBR/ZIP/etc processing.', 'warning')
+        
+        self.tar = 'tar' in available_archive_tools()
+        self.sevenzip = '7z' in available_archive_tools()
+        if not any([self.tar, self.sevenzip]):
+            self.addMessage('<a href="https://github.com/ciromattia/kcc#7-zip">Install 7z (link)</a>'
+                            ' to enable CBZ/CBR/ZIP/etc processing.', 'warning')
         self.detectKindleGen(True)
 
         APP.messageFromOtherInstance.connect(self.handleMessage)

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -18,6 +18,7 @@
 # PERFORMANCE OF THIS SOFTWARE.
 #
 
+from functools import lru_cache
 import os
 from hashlib import md5
 from html.parser import HTMLParser
@@ -136,6 +137,19 @@ def dependencyCheck(level):
     if len(missing) > 0:
         print('ERROR: ' + ', '.join(missing) + ' is not installed!')
         sys.exit(1)
+
+@lru_cache
+def available_archive_tools():
+    available = []
+
+    for tool in ['tar', '7z', 'unar', 'unrar']:
+        try:
+            subprocess_run([tool], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            available.append(tool)
+        except FileNotFoundError:
+            pass
+    
+    return available
 
 def subprocess_run(command, **kwargs):
     if (os.name == 'nt'):


### PR DESCRIPTION
@utopiafallen Thanks, I saw about a 5x speedup on macOS. I changed your `subprocess.run` to make it multiplatform and made 7z a preference but falling back to older method if 7z not available.

> Speed up zip file creation by using 7z
> - 7z is about 10x faster than whatever the Python ZipFile library was doing, probably because compression is multithreaded by default in 7z, so makeZip() now just calls through to 7z.