### PR TITLE
Bug/850/setting empty metadata

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -80,6 +80,8 @@ def main(argv=None):
 def buildHTML(path, imgfile, imgfilepath):
     filename = getImageFileName(imgfile)
     deviceres = options.profileData[1]
+    if not imgfilepath in options.imgMetadata:
+        options.imgMetadata[imgfilepath] = []
     if not options.noprocessing and "Rotated" in options.imgMetadata[imgfilepath]:
         rotatedPage = True
     else:
@@ -813,7 +815,12 @@ def sanitizeTree(filetree):
             key = os.path.join(root, name)
             if key != newKey:
                 os.replace(key, newKey)
-                options.imgMetadata[newKey] = options.imgMetadata.pop(key)
+                if key in options.imgMetadata:
+                    options.imgMetadata[newKey] = options.imgMetadata.pop(key)
+                else:
+                    options.imgMetadata[newKey] = []
+                    print(f"WARNING: {key} not in options.imgMetadata")
+                
         for i, name in enumerate(dirs):
             tmpName = name
             slugified = slugify(name)

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -819,7 +819,6 @@ def sanitizeTree(filetree):
                     options.imgMetadata[newKey] = options.imgMetadata.pop(key)
                 else:
                     options.imgMetadata[newKey] = []
-                    print(f"WARNING: {key} not in options.imgMetadata")
                 
         for i, name in enumerate(dirs):
             tmpName = name


### PR DESCRIPTION
Ignoring missing image metadata (https://github.com/ciromattia/kcc/issues/850)
During conversion, the code expected that every processed file has a
metadata object attached in imgMetadata dictionary. For some reason this
is not true for every file.
I've added code that adds empty metadata to every file where the
metadata is missing.
This is more of a workaround, so the conversion can finish, it would be
better to find out why the metadata is missing in the first place, but I
don't see that.
Since most images have empty metadata, I don't think we are missing any
information.

This fixes https://github.com/ciromattia/kcc/issues/850