### PR TITLE
memory optimization: store metadata in filenames, not a global dict

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -556,7 +556,6 @@ def imgDirectoryProcessing(path):
     global workerPool, workerOutput
     workerPool = Pool(maxtasksperchild=100)
     workerOutput = []
-    options.imgOld = []
     work = []
     pagenumber = 0
     for dirpath, _, filenames in os.walk(path):
@@ -579,9 +578,6 @@ def imgDirectoryProcessing(path):
         if len(workerOutput) > 0:
             rmtree(os.path.join(path, '..', '..'), True)
             raise RuntimeError("One of workers crashed. Cause: " + workerOutput[0][0], workerOutput[0][1])
-        for file in options.imgOld:
-            if os.path.isfile(file):
-                os.remove(file)
     else:
         rmtree(os.path.join(path, '..', '..'), True)
         raise UserWarning("Source directory is empty.")
@@ -591,10 +587,7 @@ def imgFileProcessingTick(output):
     if isinstance(output, tuple):
         workerOutput.append(output)
         workerPool.terminate()
-    else:
-        for page in output:
-            if page is not None:
-                options.imgOld.append(page[1])
+
     if GUI:
         GUI.progressBarTick.emit('tick')
         if not GUI.conversionAlive:

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -77,15 +77,14 @@ def main(argv=None):
     return 0
 
 
-def buildHTML(path, imgfile, imgfilepath):
-    key = pathlib.Path(imgfilepath).name
+def buildHTML(path, imgfile):
     filename = getImageFileName(imgfile)
     deviceres = options.profileData[1]
-    if not options.noprocessing and "Rotated" in options.imgMetadata[key]:
+    if not options.noprocessing and "Rotated" in imgfile:
         rotatedPage = True
     else:
         rotatedPage = False
-    if not options.noprocessing and "BlackBackground" in options.imgMetadata[key]:
+    if not options.noprocessing and "BlackBackground" in imgfile:
         additionalStyle = 'background-color:#000000;'
     else:
         additionalStyle = ''
@@ -518,7 +517,7 @@ def buildEPUB(path, chapternames, tomenumber, ischunked):
             if not chapter:
                 chapterlist.append((dirpath.replace('Images', 'Text'), afile))
                 chapter = True
-            filelist.append(buildHTML(dirpath, afile, os.path.join(dirpath, afile)))
+            filelist.append(buildHTML(dirpath, afile))
     build_html_end = perf_counter()
     print(f"buildHTML: {build_html_end - build_html_start} seconds")
     # Overwrite chapternames if tree is flat and ComicInfo.xml has bookmarks
@@ -557,7 +556,6 @@ def imgDirectoryProcessing(path):
     global workerPool, workerOutput
     workerPool = Pool(maxtasksperchild=100)
     workerOutput = []
-    options.imgMetadata = {}
     options.imgOld = []
     work = []
     pagenumber = 0
@@ -596,8 +594,7 @@ def imgFileProcessingTick(output):
     else:
         for page in output:
             if page is not None:
-                options.imgMetadata[page[0]] = page[1]
-                options.imgOld.append(page[2])
+                options.imgOld.append(page[1])
     if GUI:
         GUI.progressBarTick.emit('tick')
         if not GUI.conversionAlive:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -320,7 +320,9 @@ class ComicPage:
                             output_jpeg_file.write(output_jpeg_bytes)
                 else:
                     self.image.save(self.targetPath, 'JPEG', optimize=1, quality=85)
-            return [Path(self.targetPath).name, self.orgPath]
+            if os.path.isfile(self.orgPath):
+                os.remove(self.orgPath)
+            return Path(self.targetPath).name
         except IOError as err:
             raise RuntimeError('Cannot save image. ' + str(err))
 

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -299,13 +299,12 @@ class ComicPage:
 
     def saveToDir(self):
         try:
-            flags = []
             if not self.opt.forcecolor and not self.opt.forcepng:
                 self.image = self.image.convert('L')
             if self.rotated:
-                flags.append('Rotated')
+                self.targetPath += '-Rotated'
             if self.fill != 'white':
-                flags.append('BlackBackground')
+                self.targetPath += '-BlackBackground'
             if self.opt.forcepng:
                 self.image.info["transparency"] = None
                 self.targetPath += '.png'
@@ -321,7 +320,7 @@ class ComicPage:
                             output_jpeg_file.write(output_jpeg_bytes)
                 else:
                     self.image.save(self.targetPath, 'JPEG', optimize=1, quality=85)
-            return [Path(self.targetPath).name, flags, self.orgPath]
+            return [Path(self.targetPath).name, self.orgPath]
         except IOError as err:
             raise RuntimeError('Cannot save image. ' + str(err))
 


### PR DESCRIPTION
@Lukas-Holecy This should also fix your memory issues. Instead of metadata dicts, store the metadata in the filename. this matters because image processing is parallelized.

- fix https://github.com/ciromattia/kcc/issues/850#issuecomment-2706339742