### PR TITLE
revert build windows gui with docker

### DIFF
--- a/.github/workflows/package-windows-with-docker.yml
+++ b/.github/workflows/package-windows-with-docker.yml
@@ -29,11 +29,6 @@ jobs:
         uses: JackMcKew/pyinstaller-action-windows@main
         with:
           path: .
-          spec: ./kcc.spec
-      - name: Package Application
-        uses: JackMcKew/pyinstaller-action-windows@main
-        with:
-          path: .
           spec: ./kcc-c2e.spec
       - name: Package Application
         uses: JackMcKew/pyinstaller-action-windows@main
@@ -43,7 +38,6 @@ jobs:
       - name: rename binaries
         run: |   
           version_built=$(cat kindlecomicconverter/__init__.py | grep version | awk '{print $3}' | sed "s/[^.0-9b]//g")
-          mv dist/windows/kcc.exe dist/windows/KCC_${version_built}.exe 
           mv dist/windows/kcc-c2e.exe dist/windows/KCC_c2e_${version_built}.exe 
           mv dist/windows/kcc-c2p.exe dist/windows/KCC_c2p_${version_built}.exe
 


### PR DESCRIPTION
testing now that we are signed which process gives less AV flags.

Also, this lets things be more parallel since building 3 exe sequentially is SLOW.