### PR TITLE
split covers in half if too wide

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -430,6 +430,12 @@ class Cover:
         self.image = ImageOps.autocontrast(self.image)
         if not self.options.forcecolor:
             self.image = self.image.convert('L')
+        w, h = self.image.size
+        if w / h > 2:
+            if self.options.righttoleft:
+                self.image = self.image.crop((0, 0, w/2 + w * 0.02, h))
+            else:
+                self.image = self.image.crop((w/2 - w * 0.02, 0, w, h))
         self.image.thumbnail(self.options.profileData[1], Image.Resampling.LANCZOS)
         self.save()
 


### PR DESCRIPTION
- related #856 

since cover is duplicated, you see the split version in library view.