### PR TITLE
speed optimization: fix accidentally cropping pages twice

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -613,7 +613,7 @@ def imgFileProcessing(work):
             img = image.ComicPage(opt, *i)
             if opt.cropping == 2 and not opt.webtoon:
                 img.cropPageNumber(opt.croppingp, opt.croppingm)
-            if opt.cropping == 1 0 and not opt.webtoon:
+            if opt.cropping == 1 and not opt.webtoon:
                 img.cropMargin(opt.croppingp, opt.croppingm)
             if opt.interpanelcrop > 0:
                 img.cropInterPanelEmptySections("horizontal" if opt.interpanelcrop == 1 else "both")

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -613,7 +613,7 @@ def imgFileProcessing(work):
             img = image.ComicPage(opt, *i)
             if opt.cropping == 2 and not opt.webtoon:
                 img.cropPageNumber(opt.croppingp, opt.croppingm)
-            if opt.cropping > 0 and not opt.webtoon:
+            if opt.cropping == 1 0 and not opt.webtoon:
                 img.cropMargin(opt.croppingp, opt.croppingm)
             if opt.interpanelcrop > 0:
                 img.cropInterPanelEmptySections("horizontal" if opt.interpanelcrop == 1 else "both")


### PR DESCRIPTION
@neyney10 This looks fine? I noticed the `maybeCrop` function was being called twice per image, this shaves a second per volume for me.