### PR TITLE
fix webtoon page numbers 

### DIFF
--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -181,7 +181,7 @@ def splitImage(work):
                         panelImg = imgOrg.crop((0, panelsProcessed[panel][0], widthImg, panelsProcessed[panel][1]))
                         newPage.paste(panelImg, (0, targetHeight))
                         targetHeight += panelsProcessed[panel][2]
-                    newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(pageNumber) + '.png'), 'PNG')
+                    newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(pageNumber).zfill(4) + '.png'), 'PNG')
                     pageNumber += 1
             os.remove(filePath)
     except Exception:


### PR DESCRIPTION
I found that in the comic2panel.py file there is the following line: newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(pageNumber) + '.png'), 'PNG') which causes that, if the name of the webton is not divided correctly, it uses the numbering 1,2,...,10 and that causes errors in some ereaders, if it is changed to: newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(pageNumber).zfill(4) + '.png'), 'PNG') now it uses the numbering 0001,0001,...,0010 which does not cause those errors