### PR TITLE
CBZ output: Don't add padding around images when upscale unchecked or when white background is checked

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -372,7 +372,7 @@ class ComicPage:
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
                 self.image = ImageOps.fit(self.image, self.size, method=method)
-            elif self.opt.format == 'CBZ' or self.opt.kfx:
+            elif (self.opt.format == 'CBZ' or self.opt.kfx) and not self.opt.white_borders:
                 self.image = ImageOps.pad(self.image, self.size, method=method, color=self.fill)
             else:
                 if self.kindle_scribe_azw3:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -368,12 +368,7 @@ class ComicPage:
         if self.opt.stretch:
             self.image = self.image.resize(self.size, method)
         elif method == Image.Resampling.BICUBIC and not self.opt.upscale:
-            if self.opt.format == 'CBZ' or self.opt.kfx:
-                borderw = int((self.size[0] - self.image.size[0]) / 2)
-                borderh = int((self.size[1] - self.image.size[1]) / 2)
-                self.image = ImageOps.expand(self.image, border=(borderw, borderh), fill=self.fill)
-                if self.image.size[0] != self.size[0] or self.image.size[1] != self.size[1]:
-                    self.image = ImageOps.fit(self.image, self.size, method=method)
+            pass
         else: # if image bigger than device resolution or smaller with upscaling
             if abs(ratio_image - ratio_device) < AUTO_CROP_THRESHOLD:
                 self.image = ImageOps.fit(self.image, self.size, method=method)
@@ -385,7 +380,7 @@ class ComicPage:
                 self.image = ImageOps.contain(self.image, self.size, method=method)
 
     def resize_method(self):
-        if self.image.size[0] <= self.size[0] and self.image.size[1] <= self.size[1]:
+        if self.image.size[0] < self.size[0] and self.image.size[1] < self.size[1]:
             return Image.Resampling.BICUBIC
         else:
             return Image.Resampling.LANCZOS


### PR DESCRIPTION
@mergen3107 @KaMyKaSii

- related https://github.com/koreader/koreader/issues/9163#issuecomment-1146637205

Do you think this change would help koreader users?

Previously, if you used an (~800x1200) image smaller than the device (1860x2480), and **upscale is unchecked** in cbz output mode, it would add huge margins.


This code change disables the added padding and outputs the image at it's original resoltion. Since KCC doesn't upscale to the huge resolution, this should mean much smaller filesizes at the same quality compared to using the upscale option.

test builds here:

https://github.com/axu2/kcc/releases/tag/v7.4.1-mapaki-koreader