### PR TITLE
cbz output: don't change subfolder names

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -965,6 +965,8 @@ def createNewTome(parent):
 
 
 def slugify(value):
+    if options.format == 'CBZ':
+        return value
     value = slugify_ext(value, regex_pattern=r'[^-a-z0-9_\.]+').strip('.')
     value = sub(r'0*([0-9]{4,})', r'\1', sub(r'([0-9]+)', r'0000\1', value, count=2))
     return value


### PR DESCRIPTION
Do not slugify folder names when output format is CBZ 

- (fixes #914)

**What it does**

Early‑return in `slugify()` when `options.format == 'CBZ'`, so KCC keeps the
original (Unicode) folder names instead of transliterating them.

```python
def slugify(value):
    if options.format == 'CBZ':
        return value
    # existing code…
