### PR TITLE
upgrade to numpy 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ packaging>=23.2
 mozjpeg-lossless-optimization>=1.1.2
 natsort>=8.4.0
 distro>=1.8.0
-numpy>=1.22.4,<2.0.0
+numpy>=1.22.4


### PR DESCRIPTION
@neyney10 

As of Numpy 2.3, all the compatibility issues I had before seem to be gone, so I'm no longer requiring numpy 1.

Numpy 1 is a pain to install on newer Python versions.

> Just updated this and added numpy to depends; sorry for missing that!
> So, I've added a dependency on python-numpy, which is numpy 2, but upstream kcc depends on numpy 1. This could be provided with python-numpy1 (on the AUR), but that would conflict with python-numpy, and could cause issues with other packages. Apparently upstream didn't test with numpy 2 (https://github.com/ciromattia/kcc/pull/778), and I ran some tests and it seems to work fine with numpy 2, so I decided to just use that one.
>If you guys find any issue with this, please let me know and I'll switch to python-numpy1.

https://aur.archlinux.org/packages/kcc