### PR TITLE
Fixes to grayscale pages in forcecolor mode

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -642,8 +642,8 @@ def imgFileProcessing(work):
             img.autocontrastImage()
             img.resizeImage()
             img.optimizeForDisplay(opt.reducerainbow)
-            if (opt.forcepng and not opt.forcecolor) or (opt.forcepng and opt.forcecolor and not workImg.color):
-                img.quantizeImage()
+            if not opt.forcecolor or (opt.forcecolor and not workImg.color):
+                img.convertToGrayscaleOrQuantize()
             output.append(img.saveToDir())
         return output
     except Exception:

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -642,7 +642,7 @@ def imgFileProcessing(work):
             img.autocontrastImage()
             img.resizeImage()
             img.optimizeForDisplay(opt.reducerainbow)
-            if opt.forcepng and not opt.forcecolor:
+            if (opt.forcepng and not opt.forcecolor) or (opt.forcepng and opt.forcecolor and not workImg.color):
                 img.quantizeImage()
             output.append(img.saveToDir())
         return output

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -304,8 +304,6 @@ class ComicPage:
     def saveToDir(self):
         try:
             flags = []
-            if not self.opt.forcecolor and not self.opt.forcepng:
-                self.image = self.image.convert('L')
             if self.rotated:
                 flags.append('Rotated')
             if self.fill != 'white':
@@ -352,6 +350,12 @@ class ComicPage:
             self.image = ImageOps.autocontrast(self.image)
         else:
             self.image = ImageOps.autocontrast(Image.eval(self.image, lambda a: int(255 * (a / 255.) ** gamma)))
+
+    def convertToGrayscaleOrQuantize(self):
+        if self.opt.forcepng:
+            self.quantizeImage()
+        else:
+            self.image = self.image.convert('L')
 
     def quantizeImage(self):
         colors = len(self.palette) // 3


### PR DESCRIPTION
Fixes bit depth/quantization for grayscale pages with forcepng + forcecolor options.
Now color pages will be saved in 8bit truecolor (24bit per pixel) and grayscale pages in 8bit (2bit/4bit/8bit dynamically based on given quantization palette after https://github.com/ciromattia/kcc/pull/976 is merged)

Closes https://github.com/ciromattia/kcc/issues/932

Slight optimization to JPEG grayscale pages with forcecolor option.
Consistently results in ~0.7% reduction in output file size.