### PR TITLE
only add display-block for kindle scribe

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -448,10 +448,13 @@ def buildEPUB(path, chapternames, tomenumber, ischunked, cover: image.Cover, len
                   "margin: 0;\n",
                   "padding: 0;\n",
                   "}\n",
-                  "img {\n",
-                  "display: block;\n",
-                  "}\n",
                   ])
+    if options.kindle_scribe_azw3:
+        f.writelines([
+                    "img {\n",
+                    "display: block;\n",
+                    "}\n",
+                    ])
     if options.iskindle and options.panelview:
         f.writelines(["#PV {\n",
                       "position: absolute;\n",


### PR DESCRIPTION
- #972 

apparently this change broke the mupdf renderer for epubs, not sure how many people actually use that though. So I'll only add it when needed.

@9783e6 