### PR TITLE
Improved color detection

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -647,7 +647,7 @@ def imgFileProcessing(work):
             img.autocontrastImage()
             img.resizeImage()
             img.optimizeForDisplay(opt.reducerainbow)
-            if opt.forcecolor and workImg.color:
+            if opt.forcecolor and img.color:
                 pass
             elif opt.forcepng:
                 img.quantizeImage()

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -285,10 +285,10 @@ class ComicPage:
         img = self.image.convert("YCbCr")
         _, cb, cr = img.split()
 
-        cb_hist = np.array(cb.histogram())
-        cr_hist = np.array(cr.histogram())
-        cb_nonzero = np.where(cb_hist > 0)[0]
-        cr_nonzero = np.where(cr_hist > 0)[0]
+        cb_hist = cb.histogram()
+        cr_hist = cr.histogram()
+        cb_nonzero = [i for i, e in enumerate(cb_hist) if e]
+        cr_nonzero = [i for i, e in enumerate(cr_hist) if e]
         cb_spread = cb_nonzero[-1] - cb_nonzero[0] if len(cb_nonzero) else 0
         cr_spread = cr_nonzero[-1] - cr_nonzero[0] if len(cr_nonzero) else 0
 


### PR DESCRIPTION
Improves the color detection algorithm to better handle images that contain only small regions of color but have a low overall color-to-pixel ratio. Previously, such images were often misclassified as grayscale, even when they did contain color. With this change, these pages are now correctly identified as color, reducing false negatives in color detection.

Additionally, this PR makes the color check run only when it’s actually needed, instead of running it up front every time. This avoids doing extra work if the color check isn’t used, which reduces unnecessary computation.

- Closes https://github.com/ciromattia/kcc/issues/995