### PR TITLE
only slugify cbz subfolders if sort matters

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -849,8 +849,7 @@ def sanitizeTree(filetree):
             if not cover_path:
                 cover_path = newKey
         is_natural_sorted = False
-        os_sorted_dirs = os_sorted(dirs)
-        if os_sorted_dirs == sorted(dirs):
+        if os_sorted(dirs) == sorted(dirs):
             is_natural_sorted = True
         dirs.sort(key=OS_SORT_KEY)
         for i, name in enumerate(dirs):


### PR DESCRIPTION
- fix #1006 

Only slugify if the sort order would change.

If it’s already 01 02 it won’t change it. Since that will sort properly anywhere 

It would only change if it was like 9 10 because some devices will sort 10 before 9. Then it would become 09 10

Thanks for your input.