### PR TITLE
don't autocontrast color content

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -639,21 +639,22 @@ def imgFileProcessing(work):
         workImg = image.ComicPageParser((dirpath, afile), opt)
         for i in workImg.payload:
             img = image.ComicPage(opt, *i)
+            is_not_color = not opt.forcecolor or not img.color
+            if is_not_color:
+                img.convertToGrayscale()
             if opt.cropping == 2 and not opt.webtoon:
                 img.cropPageNumber(opt.croppingp, opt.croppingm)
             if opt.cropping == 1 and not opt.webtoon:
                 img.cropMargin(opt.croppingp, opt.croppingm)
             if opt.interpanelcrop > 0:
                 img.cropInterPanelEmptySections("horizontal" if opt.interpanelcrop == 1 else "both")
-            img.autocontrastImage()
+            img.gammaCorrectImage()
+            if is_not_color:
+                img.autocontrastImage()
             img.resizeImage()
             img.optimizeForDisplay(opt.reducerainbow)
-            if opt.forcecolor and img.color:
-                pass
-            elif opt.forcepng:
+            if is_not_color and opt.forcepng:
                 img.quantizeImage()
-            else:
-                img.convertToGrayscale()
             output.append(img.saveToDir())
         return output
     except Exception:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -341,16 +341,21 @@ class ComicPage:
                 image.save(targetPath, 'JPEG', optimize=1, quality=85)
         return targetPath
 
-    def autocontrastImage(self):
+    def gammaCorrectImage(self):
         gamma = self.opt.gamma
         if gamma < 0.1:
             gamma = self.gamma
             if self.gamma != 1.0 and self.color:
                 gamma = 1.0
         if gamma == 1.0:
-            self.image = ImageOps.autocontrast(self.image)
+            pass
         else:
-            self.image = ImageOps.autocontrast(Image.eval(self.image, lambda a: int(255 * (a / 255.) ** gamma)))
+            self.image = Image.eval(self.image, lambda a: int(255 * (a / 255.) ** gamma))
+
+    def autocontrastImage(self):
+        # autocontrast on non grayscale images has unexpected results 
+        # since it autocontrasts each color channel separately
+        self.image = ImageOps.autocontrast(self.image)
 
     def convertToGrayscale(self):
         self.image = self.image.convert('L')
@@ -358,7 +363,7 @@ class ComicPage:
     def quantizeImage(self):
         # remove all color pixels from image, since colorCheck() has some tolerance
         # quantize with a small number of color pixels in a mostly b/w image can have unexpected results
-        self.image = self.image.convert("L").convert("RGB")
+        self.image = self.image.convert("RGB")
 
         palImg = Image.new('P', (1, 1))
         palImg.putpalette(self.palette)


### PR DESCRIPTION
Pillow's autocontrast is the same as the old implementatin of normalize in `imagemagick`, which can have unexpected effects on color images.

https://usage.imagemagick.org/color_mods/#normalize

It normalizes each color channel separately.