### PR TITLE
pdf input uses all cpu cores

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -794,10 +794,13 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_height):
     print("Starting %i processes for '%s'." % (cpu, filename))
 
     try:
+        start = perf_counter()
         with Pool() as pool:
             results = pool.map(
                 render_page if render else extract_page, vectors
             )
+        end = perf_counter()
+        print(f"MuPDF: {end - start} sec")
     except Exception as e:
         raise UserWarning(f"Error while processing PDF pages: {e}")
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -794,7 +794,7 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_height):
     print("Starting %i processes for '%s'." % (cpu, filename))
 
     try:
-        with Pool(processes=cpu_count()-1) as pool:
+        with Pool() as pool:
             results = pool.map(
                 render_page if render else extract_page, vectors
             )


### PR DESCRIPTION
- #983 

This is way faster since the recipe requires it.

https://pymupdf.readthedocs.io/en/latest/recipes-multiprocessing.html