### PR TITLE
Fix #1037: Rainbow eraser error on odd widths

### DIFF
--- a/kindlecomicconverter/rainbow_artifacts_eraser.py
+++ b/kindlecomicconverter/rainbow_artifacts_eraser.py
@@ -213,7 +213,7 @@ def erase_rainbow_artifacts(img, is_color):
         # Process only the luminance channel
         fft_spectrum = fourier_transform_image(luminance)
         clean_spectrum = attenuate_diagonal_frequencies(fft_spectrum)
-        clean_luminance = np.fft.irfft2(clean_spectrum)
+        clean_luminance = np.fft.irfft2(clean_spectrum, s=luminance.shape)
         
         # Normalize and clip luminance
         clean_luminance = np.clip(clean_luminance, 0, 255)


### PR DESCRIPTION
Rainbow erase: add param s=luminance.shape to irfft2 to avoid dimensions error on luminance

Fixes #1037 