### PR TITLE
fix rmtree Directory not empty: 'Images'

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -464,7 +464,7 @@ class WorkerThread(QThread):
                 if os.path.isfile(path):
                     os.remove(path)
                 elif os.path.isdir(path):
-                    rmtree(path)
+                    rmtree(path, True)
         GUI.progress.content = ''
         GUI.progress.stop()
         MW.hideProgressBar.emit()

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1573,7 +1573,7 @@ def makeBook(source, qtgui=None):
         if os.path.isfile(source):
             os.remove(source)
         elif os.path.isdir(source):
-            rmtree(source)
+            rmtree(source, True)
 
     end = perf_counter()
     print(f"makeBook: {end - start} seconds")

--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -277,7 +277,7 @@ def main(argv=None, qtgui=None):
                         raise RuntimeError("One of workers crashed. Cause: " + splitWorkerOutput[0][0],
                                            splitWorkerOutput[0][1])
                     if args.inPlace:
-                        rmtree(sourceDir)
+                        rmtree(sourceDir, True)
                         move(targetDir, sourceDir)
                 else:
                     rmtree(targetDir, True)

--- a/kindlecomicconverter/metadata.py
+++ b/kindlecomicconverter/metadata.py
@@ -123,4 +123,4 @@ class MetadataParser:
                 cbx.addFile(tmpXML)
             except OSError as e:
                 raise UserWarning(e)
-            rmtree(workdir)
+            rmtree(workdir, True)


### PR DESCRIPTION
@Silver0006 @Constantin1489 

Just FYI, `rmtree(path, True)` is called with the `True` argument in every single other place in the codebase, this ignores errors.

Some platforms like `macos-11` will have strange errors if not called with `True`. If rmtree fails you shouldn't fail the conversion.

- https://github.com/ciromattia/kcc/issues/891#issuecomment-3146130420

