### PR TITLE
Color detection has fewer false postives

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -294,7 +294,7 @@ class ComicPage:
         cb_spread = cb_nonzero[-1] - cb_nonzero[0] if len(cb_nonzero) else 0
         cr_spread = cr_nonzero[-1] - cr_nonzero[0] if len(cr_nonzero) else 0
 
-        SPREAD_THRESHOLD=20
+        SPREAD_THRESHOLD = 50
         if cb_spread < SPREAD_THRESHOLD and cr_spread < SPREAD_THRESHOLD:
             return False
         else:


### PR DESCRIPTION
@9783e6 Just FYI

Had pairs of thresholds like this where bw images were falsely flagged as color.

```
37    28
37    29
38    32
38    33
38    33
39    27
39    27
39    35
39    35
40    33
40    33
41    32
41    32
56    113
73    176
83    114
89    124
92    163
103    87
103    176
107    142
107    163
108    182
110    85
110    87
115    122
132    144
```


A threshold of 50 meant no false positives.