### PR TITLE
fixed width webtoon

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1520,8 +1520,8 @@ def makeBook(source, qtgui=None):
     cover = image.Cover(cover_path, options)
 
     if options.webtoon:
-        y = image.ProfileData.Profiles[options.profile][1][1]
-        comic2panel.main(['-y ' + str(y), '-i', '-m', path], qtgui)
+        x, y = image.ProfileData.Profiles[options.profile][1]
+        comic2panel.main(['-y ' + str(y), '-x' + str(x), '-i', '-m', path], qtgui)
     if options.noprocessing:
         print("Do not process image, ignore any profile or processing option")
     else:

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1402,6 +1402,8 @@ def checkOptions(options):
         options.righttoleft = False
         options.upscale = True
         options.hq = False
+        options.white_borders = True
+        options.bordersColor = 'white'
     # Disable all Kindle features for other e-readers
     if options.profile == 'OTHER':
         options.panelview = False

--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -107,13 +107,11 @@ def splitImage(work):
         device_height = opt.height
         overlap_ratio = 13/16
 
-        target_width = min(w, int(device_width * 6/10))
+        target_width = 1072
         if target_width != w:
-            imgOrg = ImageOps.contain(imgOrg, (target_width, h))
+            imgOrg = ImageOps.scale(imgOrg, target_width/w)
         _, target_height = imgOrg.size
-        virtual_device_width = int(target_width * 10/6)
-        virtual_device_height = int(device_height / device_width * virtual_device_width)
-
+        virtual_device_height = device_height
         for i in range(0, target_height, int(virtual_device_height * overlap_ratio)):
             newPage = imgOrg.crop((0, i, target_width, i + virtual_device_height))
             newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(i).zfill(8) + '.png'), 'PNG')

--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -111,9 +111,11 @@ def splitImage(work):
         if target_width != w:
             imgOrg = ImageOps.contain(imgOrg, (target_width, h))
         _, target_height = imgOrg.size
+        virtual_device_width = int(target_width * 10/6)
+        virtual_device_height = int(device_height / device_width * virtual_device_width)
 
-        for i in range(0, target_height, int(device_height * overlap_ratio)):
-            newPage = imgOrg.crop((0, i, target_width, i + device_height))
+        for i in range(0, target_height, int(virtual_device_height * overlap_ratio)):
+            newPage = imgOrg.crop((0, i, target_width, i + virtual_device_height))
             newPage.save(os.path.join(path, os.path.splitext(name)[0] + '-' + str(i).zfill(8) + '.png'), 'PNG')
 
         os.remove(filePath)


### PR DESCRIPTION
This chooses a fixed pixel width for the webtoon and doesn't do any panel detection at all, just scrolling a fixed length with some overlap. So gaps between panels can be large.

The code is hardcoded to 1072 width currently, so this will only work on 300 PPI devices.

Let me know if you have thoughts. 

Essentially does the same things as this app: https://www.youtube.com/watch?v=GYH9tKC5F6M

https://github.com/axu2/kcc/releases/tag/v9.0.0-webtoon-fixed-width

- #806
- #607 
- #453

@highpepsi826
@shor-tee
@cristopher92
@paolovinoya