### PR TITLE
Fix makeZIP function to allow for special characters in folder names

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1242,7 +1242,7 @@ def makeZIP(zipfilename, basedir, isepub=False):
             mimetypeFile = open(os.path.join(basedir, 'mimetype'), 'w')
             mimetypeFile.write('application/epub+zip')
             mimetypeFile.close()
-        subprocess_run([SEVENZIP, 'a', '-tzip', zipfilename, os.path.join(basedir, "*")], capture_output=True, check=True)
+        subprocess_run([SEVENZIP, 'a', '-tzip', zipfilename, "*"], capture_output=True, check=True, cwd=basedir)
     else:
         zipOutput = ZipFile(zipfilename, 'w', ZIP_DEFLATED)
         if isepub:


### PR DESCRIPTION
Linux (and probably macOS) filesystems allow for folders with special characters in it.  This appears to cause issues when a folder that contains a question mark is passed to 7zip within the makeZIP function.  Since ? is considered a wildcard character, 7zip ends up adding additional folders to the zip file, which results in an epub with incorrect structure.

To solve this, we can pass `cwd=basedir` within subprocess_run so that 7zip is executed within basedir, and have 7zip archive everything within that folder.

This should 
- fix #1085 