### PR TITLE
Fix [WinError 32] The process cannot access the file because it is being used by another process

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -151,7 +151,8 @@ class ComicPageParser:
         # Detect corruption in source image, let caller catch any exceptions triggered.
         srcImgPath = os.path.join(source[0], source[1])
         Image.open(srcImgPath).verify()
-        self.image = Image.open(srcImgPath)
+        with Image.open(srcImgPath) as im:
+            self.image = im.copy()
 
         self.fill = self.fillCheck()
         # backwards compatibility for Pillow >9.1.0


### PR DESCRIPTION
Multiframe gif images are not closed automatically by Pillow. So we make a copy and close the file manually. This doesn't seem to affect speed.

https://pillow.readthedocs.io/en/stable/reference/open_files.html#image-lifecycle

test builds:
https://github.com/axu2/kcc/releases/tag/v9.1.0-gif

@utopiafallen I think this sounds similar to an issue you had before? The error occured when it tried to delete

- https://github.com/ciromattia/kcc/pull/838/commits/35f20e82230a27f9f01eedb51043c31c3858cb27