### PR TITLE
fix typo: change "profil" to "profile" in the cli and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ MAIN:
                         the maximal size of output file in MB. [Default=100MB for webtoon and 400MB for others]
 
 PROCESSING:
-  -n, --noprocessing    Do not modify image and ignore any profil or processing option
+  -n, --noprocessing    Do not modify image and ignore any profile or processing option
   -u, --upscale         Resize images smaller than device's resolution
   -s, --stretch         Stretch images to device's resolution
   -r SPLITTER, --splitter SPLITTER

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1313,7 +1313,7 @@ def makeParser():
                                 help="Put rotated 2 page spread first in spread splitter option.")
 
     processing_options.add_argument("-n", "--noprocessing", action="store_true", dest="noprocessing", default=False,
-                                    help="Do not modify image and ignore any profil or processing option")
+                                    help="Do not modify image and ignore any profile or processing option")
     processing_options.add_argument("-u", "--upscale", action="store_true", dest="upscale", default=False,
                                     help="Resize images smaller than device's resolution")
     processing_options.add_argument("-s", "--stretch", action="store_true", dest="stretch", default=False,


### PR DESCRIPTION
found a typo* in the spelling of "profile" in README.md and the c2e CLI;

*checked the entire repo by searching for the regex `profil[^\w]`