### PR TITLE
fix webtoon panel detection

### DIFF
--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -23,7 +23,7 @@ import sys
 from argparse import ArgumentParser
 from shutil import rmtree, copytree, move
 from multiprocessing import Pool
-from PIL import Image, ImageChops, ImageOps, ImageDraw
+from PIL import Image, ImageChops, ImageOps, ImageDraw, ImageFilter
 from .shared import dot_clean, getImageFileName, walkLevel, walkSort, sanitizeTrace
 
 
@@ -101,7 +101,9 @@ def splitImage(work):
         Image.warnings.simplefilter('error', Image.DecompressionBombWarning)
         Image.MAX_IMAGE_PIXELS = 1000000000
         imgOrg = Image.open(filePath).convert('RGB')
-        imgProcess = Image.open(filePath).convert('1')
+        # I experimented with setting dither=None, but got very poor results
+        # The default dither is good
+        imgProcess = Image.open(filePath).filter(ImageFilter.FIND_EDGES).convert('1')
         widthImg, heightImg = imgOrg.size
         if heightImg > opt.height:
             if opt.debug:


### PR DESCRIPTION
- fix #453 

We have added edge detection as the measure of importance of an image part. Especially important when background isn't pure black or white.