### PR TITLE
fix webtoon panel detection by doubling max height

### DIFF
--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -58,8 +58,8 @@ def mergeDirectory(work):
                 imagesValid.append(i[0])
             # Silently drop directories that contain too many images
             # 131072 = GIMP_MAX_IMAGE_SIZE / 4
-            if targetHeight > 131072:
-                return None
+            if targetHeight > 131072 * 2:
+                raise RuntimeError(f'Image too tall at {targetHeight} pixels.')
             result = Image.new('RGB', (targetWidth, targetHeight))
             y = 0
             for i in imagesValid:


### PR DESCRIPTION
@AcidWeb 

Webtoon images aren't merged if max height is surpassed. This means panel detection is broken. 

I assume just doubling the maximum causes no issue.

https://github.com/axu2/kcc/releases/tag/v9.1.0-webtoon-renames