### PR TITLE
default jpg quality of 90 for scribe/colorsoft, bigger files but fixes blanks hopefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ PROCESSING:
   --forcecolor          Don't convert images to grayscale
   --forcepng            Create PNG files instead JPEG
   --mozjpeg             Create JPEG files using mozJpeg
+  --jpeg-quality        The JPEG quality, on a scale from 0 (worst) to 95 (best). Default 85 for most devices.
   --maximizestrips      Turn 1x4 strips to 2x2 strips
   -d, --delete          Delete source file(s) or a directory. It's not recoverable.
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1380,6 +1380,8 @@ def makeParser():
                                     help="Create PNG files instead JPEG")
     processing_options.add_argument("--mozjpeg", action="store_true", dest="mozjpeg", default=False,
                                     help="Create JPEG files using mozJpeg")
+    processing_options.add_argument("--jpeg-quality", type=int, dest="jpegquality", 
+                                    help="The JPEG quality, on a scale from 0 (worst) to 95 (best). Default 85 for most devices.")
     processing_options.add_argument("--maximizestrips", action="store_true", dest="maximizestrips", default=False,
                                     help="Turn 1x4 strips to 2x2 strips")
     processing_options.add_argument("-d", "--delete", action="store_true", dest="delete", default=False,
@@ -1479,6 +1481,11 @@ def checkOptions(options):
         image.ProfileData.Profiles["Custom"] = newProfile
         options.profile = "Custom"
     options.profileData = image.ProfileData.Profiles[options.profile]
+    if not options.jpegquality:
+        if options.profile.startswith('KS') or options.profile == 'KCS':
+            options.jpegquality = 90
+        else:
+            options.jpegquality = 85
     return options
 
 

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -408,13 +408,13 @@ class ComicPage:
             targetPath += '.jpg'
             if self.opt.mozjpeg:
                 with io.BytesIO() as output:
-                    image.save(output, format="JPEG", optimize=1, quality=85)
+                    image.save(output, format="JPEG", optimize=1, quality=self.opt.jpegquality)
                     input_jpeg_bytes = output.getvalue()
                     output_jpeg_bytes = mozjpeg_lossless_optimization.optimize(input_jpeg_bytes)
                     with open(targetPath, "wb") as output_jpeg_file:
                         output_jpeg_file.write(output_jpeg_bytes)
             else:
-                image.save(targetPath, 'JPEG', optimize=1, quality=85)
+                image.save(targetPath, 'JPEG', optimize=1, quality=self.opt.jpegquality)
         return targetPath
 
     def gammaCorrectImage(self):
@@ -584,7 +584,7 @@ class Cover:
     def save_to_epub(self, target, tomeid, len_tomes=0):
         try:
             if tomeid == 0:
-                self.image.save(target, "JPEG", optimize=1, quality=85)
+                self.image.save(target, "JPEG", optimize=1, quality=self.options.jpegquality)
             else:
                 copy = self.image.copy()
                 draw = ImageDraw.Draw(copy)
@@ -598,7 +598,7 @@ class Cover:
                     stroke_fill=0,
                     stroke_width=25
                 )
-                copy.save(target, "JPEG", optimize=1, quality=85)
+                copy.save(target, "JPEG", optimize=1, quality=self.options.jpegquality)
         except IOError:
             raise RuntimeError('Failed to save cover.')
 
@@ -606,6 +606,6 @@ class Cover:
         self.image = ImageOps.contain(self.image, (300, 470), Image.Resampling.LANCZOS)
         try:
             self.image.save(os.path.join(kindle.path.split('documents')[0], 'system', 'thumbnails',
-                                         'thumbnail_' + asin + '_EBOK_portrait.jpg'), 'JPEG', optimize=1, quality=85)
+                                         'thumbnail_' + asin + '_EBOK_portrait.jpg'), 'JPEG', optimize=1, quality=self.options.jpegquality)
         except IOError:
             raise RuntimeError('Failed to upload cover.')


### PR DESCRIPTION
- fix #768 
- fix #1163 