### PR TITLE
fix file order for fusion in c2e

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -67,7 +67,7 @@ def main(argv=None):
     if sys.platform.startswith('win'):
         sources = [source for option in options.input for source in glob(escape(option))]
     else:
-        sources = list(options.input)
+        sources = options.input
     if len(sources) == 0:
         print('No matching files found.')
         return 1


### PR DESCRIPTION
Previously, input sources were collected into a set, which caused files to be processed in an arbitrary order rather than the order specified on the command line. This change switches to using a list, ensuring that files are processed in the exact order provided by the user.