### PR TITLE
Add third-party projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,3 +434,8 @@ Copyright (c) 2012-2025 Ciro Mattia Gonano, Paweł Jastrzębski, Darodi and Alex
 
 ## Verification
 Impact-Site-Verification: ffe48fc7-4f0c-40fd-bd2e-59f4d7205180
+
+## Third-party projects
+
+- **KCC Cloud** — A third-party, self-hosted web interface that uses Kindle Comic Converter as its conversion engine.  
+  https://github.com/nilsleo/kcc-cloud


### PR DESCRIPTION
Added a section for third-party projects in README.

Hi,

This PR adds a small link under Third-party projects to KCC Cloud, my separate open-source project that provides a self-hosted web interface using Kindle Comic Converter as its conversion engine.

The project is:

- fully open source (ISC license)
- maintained independently
- clearly marked as not an official KCC project

Please let me know if it would be possible to link my Project to this one :)

Thanks for maintaining KCC — it’s an excellent project.

— Nils