### PR TITLE
clarify coverfill is not implemented for kindle scribe

### DIFF
--- a/gui/KCC.ui
+++ b/gui/KCC.ui
@@ -912,7 +912,7 @@ Useful for really weird PDFs.</string>
         <widget class="QCheckBox" name="coverFillBox">
          <property name="toolTip">
           <string>Resize cover to exact device resolution by center-cropping to aspect ratio first.
-May crop top/bottom or left/right depending on source aspect ratio.</string>
+May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.</string>
          </property>
          <property name="text">
           <string>Cover Fill</string>

--- a/kindlecomicconverter/KCC_ui.py
+++ b/kindlecomicconverter/KCC_ui.py
@@ -752,7 +752,7 @@ class Ui_mainWindow(object):
         self.pdfExtractBox.setText(QCoreApplication.translate("mainWindow", u"PDF Legacy Extract", None))
 #if QT_CONFIG(tooltip)
         self.coverFillBox.setToolTip(QCoreApplication.translate("mainWindow", u"Resize cover to exact device resolution by center-cropping to aspect ratio first.\n"
-"May crop top/bottom or left/right depending on source aspect ratio.", None))
+"May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.", None))
 #endif // QT_CONFIG(tooltip)
         self.coverFillBox.setText(QCoreApplication.translate("mainWindow", u"Cover Fill", None))
         self.gammaLabel.setText(QCoreApplication.translate("mainWindow", u"Gamma: Auto", None))

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -569,7 +569,8 @@ class Cover:
         if self.options.kindle_scribe_azw3:
             size[0] = min(size[0], 1920)
             size[1] = min(size[1], 1920)
-        if self.options.coverfill:
+        if self.options.coverfill and not self.options.kindle_scribe_azw3:
+            # TODO: Kindle Scribe case
             self.image = ImageOps.fit(self.image, tuple(size), Image.Resampling.LANCZOS, centering=(0.5, 0.5))
         else:
             self.image.thumbnail(tuple(size), Image.Resampling.LANCZOS)


### PR DESCRIPTION
@tswh0 just FYI, the scribe is unforunately quite different than all other devices, so this is not implemented for that class of device.

There is no need to implement unless you feel like it or there is demand, it might be messy.