### PR TITLE
if cropping, render pdf to 2x

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -892,10 +892,10 @@ def getWorkFolder(afile, workdir=None):
                     raise UserWarning("Failed to extract images from PDF file.")
                 return workdir
             target_width, target_height = options.profileData[1]
-            if options.cropping == 1:
-                target_height = target_height + target_height*0.20 #Account for possible margin at the top and bottom
-            elif options.cropping == 2:
-                target_height = target_height + target_height*0.25 #Account for possible margin at the top and bottom with page number
+            #Account for possible margin at the top and bottom
+            if options.cropping:
+                target_width  *= 2
+                target_height *= 2
             try:
                 mupdf_pdf_process_pages_parallel(afile, fullPath, target_width, target_height)
             except Exception as e:


### PR DESCRIPTION
@9783e6 

This way, uncropped pages get a really clean 2x downscale and cropped pages don't get a slight mismatch when downscaling a small amount.