### PR TITLE
Add kindling as preferred MOBI conversion backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ RUN \
     ln -s /opt/kcc/kcc-c2e.py /usr/local/bin/c2e && \
     ln -s /opt/kcc/kcc-c2p.py /usr/local/bin/c2p && \
     ln -s /opt/kcc/entrypoint.sh /usr/local/bin/entrypoint && \
-    ln -s /opt/kcc/kindlegen/kindlegen /usr/local/bin/kindlegen && \
+    (test -f /usr/local/bin/kindling && true || \
+     ln -s /opt/kcc/kindlegen/kindlegen /usr/local/bin/kindlegen) && \
     cat /opt/kcc/kindlecomicconverter/__init__.py | grep version | awk '{print $3}' | sed "s/'//g" > /IMAGE_VERSION
 
 LABEL com.kcc.name="Kindle Comic Converter" \

--- a/README.md
+++ b/README.md
@@ -147,11 +147,15 @@ For flatpak, Docker, and AppImage versions, refer to the wiki: https://github.co
 
 You'll need to install various tools to access important but optional features. Close and re-open KCC to get KCC to detect them.
 
-### KindleGen
+### Kindling (recommended) or KindleGen
 
-On Windows and macOS, install [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011) and `kindlegen` will be autodetected from it.
+For MOBI conversion, KCC supports [Kindling](https://github.com/ciscoriordan/kindling) or KindleGen. Kindling is preferred - it is an open-source, cross-platform Rust replacement for Amazon's deprecated KindleGen that produces the same dual KF7+KF8 MOBI output with HD images.
 
-If you have issues detecting it, get stuck on the MOBI conversion step, or use Linux AppImage or Flatpak, refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation#kindlegen
+Download the latest kindling binary for your platform from [kindling releases](https://github.com/ciscoriordan/kindling/releases) and place it on your PATH. KCC will auto-detect it.
+
+If kindling is not found, KCC falls back to KindleGen. On Windows and macOS, install [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011) and `kindlegen` will be autodetected from it.
+
+If you have issues detecting either tool, get stuck on the MOBI conversion step, or use Linux AppImage or Flatpak, refer to the wiki: https://github.com/ciromattia/kcc/wiki/Installation#kindlegen
 
 ### 7-Zip
 

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -41,7 +41,7 @@ from packaging.version import Version
 from raven import Client
 from tempfile import gettempdir
 
-from .shared import HTMLStripper, sanitizeTrace, walkLevel, subprocess_run
+from .shared import HTMLStripper, sanitizeTrace, walkLevel, subprocess_run, detect_mobi_tool
 from .comicarchive import SEVENZIP, TAR, available_archive_tools
 from . import __version__
 from . import comic2ebook
@@ -534,11 +534,11 @@ class WorkerThread(QThread):
                                 os.remove(item)
                             if os.path.exists(item.replace('.epub', '.mobi')):
                                 os.remove(item.replace('.epub', '.mobi'))
-                        MW.addMessage.emit('KindleGen failed to create MOBI!', 'error', False)
+                        MW.addMessage.emit('MOBI conversion failed!', 'error', False)
                         MW.addMessage.emit(self.kindlegenErrorCode[1], 'error', False)
-                        MW.addTrayMessage.emit('KindleGen failed to create MOBI!', 'Critical')
+                        MW.addTrayMessage.emit('MOBI conversion failed!', 'Critical')
                         if self.kindlegenErrorCode[0] == 1 and self.kindlegenErrorCode[1] != '':
-                            MW.showDialog.emit("KindleGen error:\n\n" + self.kindlegenErrorCode[1], 'error')
+                            MW.showDialog.emit("MOBI conversion error:\n\n" + self.kindlegenErrorCode[1], 'error')
                         if self.kindlegenErrorCode[0] == 23026:
                             MW.addMessage.emit('Created EPUB file was too big. Weird file structure?', 'error', False)
                             MW.addMessage.emit('EPUB file: ' + str(epubSize) + 'MB. Supported size: ~350MB.', 'error',
@@ -1014,7 +1014,8 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
 
     def display_kindlegen_missing(self):
         self.addMessage(
-            '<a href="https://github.com/ciromattia/kcc#kindlegen"><b>Install KindleGen (link)</b></a> to enable MOBI conversion for Kindles!',
+            '<a href="https://github.com/ciromattia/kcc#kindlegen"><b>Install kindling or KindleGen (link)</b></a>'
+            ' to enable MOBI conversion for Kindles!',
             'error'
         )
 
@@ -1121,22 +1122,38 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         sys.exit(0)
 
     def detectKindleGen(self, startup=False):
+        # Try kindling first, then kindlegen
+        detected = detect_mobi_tool()
+        if detected == 'kindling':
+            self.kindleGen = True
+            return
+        # If neither was found yet, try the legacy chmod path for kindlegen
+        # on non-Windows systems, then re-detect.
         if not sys.platform.startswith('win'):
             try:
                 os.chmod('/usr/local/bin/kindlegen', 0o755)
             except Exception:
                 pass
-        try:
-            versionCheck = subprocess_run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8', errors='ignore', check=True)
+            if detected is None:
+                # The chmod above may have fixed permissions, so clear the
+                # cached result and retry.
+                import kindlecomicconverter.shared as _shared
+                _shared.MOBI_TOOL = None
+                detected = detect_mobi_tool()
+        if detected == 'kindlegen':
             self.kindleGen = True
-            for line in versionCheck.stdout.splitlines():
-                if 'Amazon kindlegen' in line:
-                    versionCheck = line.split('V')[1].split(' ')[0]
-                    if Version(versionCheck) < Version('2.9'):
-                        self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
-                                        ' is outdated! MOBI conversion might fail.', 'warning')
-                    break
-        except (FileNotFoundError, CalledProcessError):
+            try:
+                versionCheck = subprocess_run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, encoding='UTF-8', errors='ignore', check=True)
+                for line in versionCheck.stdout.splitlines():
+                    if 'Amazon kindlegen' in line:
+                        versionCheck = line.split('V')[1].split(' ')[0]
+                        if Version(versionCheck) < Version('2.9'):
+                            self.addMessage('Your <a href="https://www.amazon.com/b?node=23496309011">KindleGen</a>'
+                                            ' is outdated! MOBI conversion might fail.', 'warning')
+                        break
+            except (FileNotFoundError, CalledProcessError):
+                pass
+        else:
             self.kindleGen = False
             if startup:
                 self.display_kindlegen_missing()

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -43,7 +43,7 @@ from psutil import virtual_memory, disk_usage
 from html import escape as hescape
 import pymupdf
 
-from .shared import IMAGE_TYPES, getImageFileName, walkSort, walkLevel, sanitizeTrace, subprocess_run, dot_clean
+from .shared import IMAGE_TYPES, getImageFileName, walkSort, walkLevel, sanitizeTrace, subprocess_run, dot_clean, detect_mobi_tool
 from .comicarchive import SEVENZIP, available_archive_tools
 from . import comic2panel
 from . import image
@@ -1554,10 +1554,8 @@ def checkTools(source):
             print('ERROR: 7z is missing!')
             sys.exit(1)
     if options.format == 'MOBI':
-        try:
-            subprocess_run(['kindlegen', '-locale', 'en'], stdout=PIPE, stderr=STDOUT, check=True)
-        except (FileNotFoundError, CalledProcessError):
-            print('ERROR: KindleGen is missing!')
+        if detect_mobi_tool() is None:
+            print('ERROR: Neither kindling nor KindleGen found on PATH!')
             sys.exit(1)
 
 
@@ -1781,9 +1779,13 @@ def makeMOBIWorker(item):
     item = item[0]
     kindlegenErrorCode = 0
     kindlegenError = ''
+    # detect_mobi_tool() caches its result, so this is fast after the first
+    # call.  We call it here because multiprocessing workers are separate
+    # processes that do not inherit the parent's module-level MOBI_TOOL value.
+    tool = detect_mobi_tool() or 'kindlegen'
     try:
         if os.path.getsize(item) < 629145600:
-            output = subprocess_run(['kindlegen', '-dont_append_source', '-locale', 'en', item],
+            output = subprocess_run([tool, '-dont_append_source', '-locale', 'en', item],
                            stdout=PIPE, stderr=STDOUT, encoding='UTF-8', errors='ignore', check=True)
         else:
             # ERROR: EPUB too big

--- a/kindlecomicconverter/shared.py
+++ b/kindlecomicconverter/shared.py
@@ -20,6 +20,7 @@
 
 import os
 from html.parser import HTMLParser
+from shutil import which
 import subprocess
 from packaging.version import Version
 from re import split
@@ -145,3 +146,39 @@ def subprocess_run(command, **kwargs):
     if (os.name == 'nt'):
         kwargs.setdefault('creationflags', subprocess.CREATE_NO_WINDOW)
     return subprocess.run(command, **kwargs)
+
+
+# The command used to convert EPUB to MOBI.  Set by detect_mobi_tool() and
+# shared across comic2ebook (CLI) and KCC_gui.
+MOBI_TOOL = None
+
+
+def detect_mobi_tool():
+    """Detect whether kindling or kindlegen is available on PATH.
+
+    Kindling is preferred because it is actively maintained and produces
+    the same MOBI output.  When invoked without the ``build`` sub-command
+    it runs in kindlegen compatibility mode, accepting the same flags
+    (``-dont_append_source``, ``-locale en``) and printing the same
+    status codes (``:I1036:``, ``:E23026:``).
+
+    Returns the tool name ('kindling' or 'kindlegen') or None.
+    Sets the module-level MOBI_TOOL variable on success.
+    """
+    global MOBI_TOOL
+    if MOBI_TOOL is not None:
+        return MOBI_TOOL
+    for tool in ('kindling', 'kindlegen'):
+        if which(tool) is not None:
+            try:
+                subprocess_run(
+                    [tool, '-locale', 'en'],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                )
+                MOBI_TOOL = tool
+                return MOBI_TOOL
+            except (FileNotFoundError, subprocess.CalledProcessError):
+                continue
+    return None


### PR DESCRIPTION
## Summary

Adds [kindling](https://github.com/ciscoriordan/kindling) as a MOBI conversion backend, preferred over kindlegen when available.

I built kindling because kindlegen was running out of memory and taking 12+ hours trying to build Greek dictionaries with hundreds of thousands of inflected forms. It started as a dictionary-specific tool. After a user request (https://github.com/ciscoriordan/kindling/issues/1), I've since expanded it to handle EPUB-to-MOBI conversion for books and comics as well, with KF8 dual-format output, HD image container, and fixed-layout support.

Kindling is an open-source Rust replacement for kindlegen that produces the same dual KF7+KF8 MOBI output. It runs in kindlegen compatibility mode, accepting the same CLI flags (`-dont_append_source`, `-locale en`) and printing the same status codes (`:I1036:`, `:E23026:`), so the existing KCC conversion pipeline works unchanged.

Pre-built binaries for Mac (Apple Silicon + Intel), Linux, and Windows: https://github.com/ciscoriordan/kindling/releases

Tested with Pepper & Carrot comic EPUB on Kindle hardware:

![Pepper & Carrot on Kindle](https://raw.githubusercontent.com/ciscoriordan/kindling/main/kindle_comic_test.jpg)

## Changes

- `shared.py`: New `detect_mobi_tool()` that checks for `kindling` first, falls back to `kindlegen`
- `comic2ebook.py`: `checkTools()` and `makeMOBIWorker()` use `detect_mobi_tool()` instead of hardcoded `kindlegen`
- `KCC_gui.py`: GUI detection updated, error messages mention both tools
- `Dockerfile`: Skips kindlegen symlink if kindling is already on PATH
- `README.md`: Updated installation section to recommend kindling

## Test plan

- [ ] KCC with kindling on PATH produces working MOBI from comic EPUB
- [ ] KCC without kindling falls back to kindlegen
- [ ] GUI detection works for both tools
- [ ] Docker build works with and without kindling pre-installed