### PR TITLE
add webp output support (ignored for Kindle MOBI/EPUB and all PDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ PROCESSING:
   --coverfill           Center-crop only the cover to fill target device screen
   --forcecolor          Don't convert images to grayscale
   --forcepng            Create PNG files instead JPEG for black and white images
+  --webp                Replace JPG with lossy WEBP and PNG with lossless WEBP
   --force-png-rgb       Force color images to be saved as PNG
   --pnglegacy           Use a more compatible 8 bit PNG instead of 4 bit.
   --noquantize          Don't quantize PNG images to 16 colors

--- a/gui/KCC.ui
+++ b/gui/KCC.ui
@@ -549,6 +549,9 @@
        </item>
        <item row="11" column="0">
         <widget class="QCheckBox" name="pngLegacyBox">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="toolTip">
           <string>Use a more compatible 8 bit PNG instead of 4 bit.</string>
          </property>
@@ -656,6 +659,9 @@
        </item>
        <item row="10" column="2">
         <widget class="QCheckBox" name="noQuantizeBox">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="toolTip">
           <string>Don't quantize PNG images to 16 colors (4 bit)
 
@@ -814,6 +820,9 @@ Higher values are larger and higher quality, and may resolve blank page issues.<
        </item>
        <item row="11" column="2">
         <widget class="QCheckBox" name="forcePngRgbBox">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="toolTip">
           <string>Force full color images to be saved in lossless PNG format, dramatically increases the filesize.</string>
          </property>

--- a/gui/KCC.ui
+++ b/gui/KCC.ui
@@ -514,68 +514,13 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="8" column="1">
-        <widget class="QCheckBox" name="rotateFirstBox">
+       <item row="6" column="1">
+        <widget class="QCheckBox" name="noRotateBox">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the spread splitter option is partially checked,&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Rotate Last&lt;br/&gt;&lt;/span&gt;Put the rotated 2 page spread after the split spreads.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Rotate First&lt;br/&gt;&lt;/span&gt;Put the rotated 2 page spread before the split spreads.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Do not rotate double page spreads in spread splitter option.</string>
          </property>
          <property name="text">
-          <string>Rotate First</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QCheckBox" name="outputSplit">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Automatic mode&lt;br/&gt;&lt;/span&gt;The output will be split automatically.&lt;/p&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Volume mode&lt;br/&gt;&lt;/span&gt;Every subdirectory will be considered as a separate volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Output split</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QCheckBox" name="pdfWidthBox">
-         <property name="toolTip">
-          <string>Render vector PDFs to device width instead of height.
-
-Useful if you plan to crop a little off the top and bottom to fill screen.</string>
-         </property>
-         <property name="text">
-          <string>PDF Width Render</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="borderBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Autodetection&lt;br/&gt;&lt;/span&gt;The color of margins fill will be detected automatically.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - White&lt;br/&gt;&lt;/span&gt;Margins will be untouched.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Black&lt;br/&gt;&lt;/span&gt;Margins will be filled with black color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>W/B margins</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QCheckBox" name="deleteBox">
-         <property name="toolTip">
-          <string>Delete input file(s) or directory. It's not recoverable!</string>
-         </property>
-         <property name="text">
-          <string>Delete input</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QCheckBox" name="spreadShiftBox">
-         <property name="toolTip">
-          <string>Shift first page to opposite side in landscape for two page spread alignment</string>
-         </property>
-         <property name="text">
-          <string>Spread shift</string>
+          <string>No rotate</string>
          </property>
         </widget>
        </item>
@@ -589,6 +534,86 @@ Useful if you plan to crop a little off the top and bottom to fill screen.</stri
          </property>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="rotateBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Split&lt;br/&gt;&lt;/span&gt;Double page spreads will be cut into two separate pages.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Split and rotate&lt;br/&gt;&lt;/span&gt;Double page spreads will be displayed twice. First split and then rotated. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Rotate&lt;br/&gt;&lt;/span&gt;Double page spreads will be rotated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Spread splitter</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="pngLegacyBox">
+         <property name="toolTip">
+          <string>Use a more compatible 8 bit PNG instead of 4 bit.</string>
+         </property>
+         <property name="text">
+          <string>PNG Legacy Mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="2">
+        <widget class="QCheckBox" name="interPanelCropBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Disabled&lt;br/&gt;&lt;/span&gt;Disabled&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Horizontal&lt;br/&gt;&lt;/span&gt;Crop empty horizontal lines.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Both&lt;br/&gt;&lt;/span&gt;Crop empty horizontal and vertical lines.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Inter-panel crop</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLineEdit" name="titleEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::ClickFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default Title&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="placeholderText">
+          <string>Default Title</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="authorEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::ClickFocus</enum>
+         </property>
+         <property name="toolTip">
+          <string>Default Author is KCC</string>
+         </property>
+         <property name="placeholderText">
+          <string>Default Author</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="0">
         <widget class="QCheckBox" name="webtoonBox">
          <property name="toolTip">
@@ -599,23 +624,33 @@ Useful if you plan to crop a little off the top and bottom to fill screen.</stri
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
-        <widget class="QCheckBox" name="noRotateBox">
+       <item row="6" column="0">
+        <widget class="QCheckBox" name="fileFusionBox">
          <property name="toolTip">
-          <string>Do not rotate double page spreads in spread splitter option.</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Combines all selected files into a single file. (Helpful for combining chapters into volumes.)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
-          <string>No rotate</string>
+          <string>File Fusion</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QCheckBox" name="mangaBox">
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="deleteBox">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;Enable right-to-left reading.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Delete input file(s) or directory. It's not recoverable!</string>
          </property>
          <property name="text">
-          <string>Right-to-left (manga)</string>
+          <string>Delete input</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QCheckBox" name="gammaBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set a custom gamma correction.&lt;/p&gt;&lt;p&gt;1.0 is default (disabled).&lt;br/&gt;&amp;lt; 1.0 makes the image brighter.&lt;br/&gt;&amp;gt; 1.0 makes the image darker. &lt;/p&gt;&lt;p&gt;1.8 was the default in KCC 9.1.0 and earlier.&lt;/p&gt;&lt;p&gt;Use if you want to make midtones darker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Custom gamma</string>
          </property>
         </widget>
        </item>
@@ -633,6 +668,70 @@ Eink only has 16 shades of gray so you probably don't want this.</string>
          </property>
         </widget>
        </item>
+       <item row="7" column="2">
+        <widget class="QCheckBox" name="eraseRainbowBox">
+         <property name="toolTip">
+          <string>Erase rainbow effect on color eink screen by attenuating interfering frequencies</string>
+         </property>
+         <property name="text">
+          <string>Rainbow eraser</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QCheckBox" name="coverFillBox">
+         <property name="toolTip">
+          <string>Resize cover to exact device resolution by center-cropping to aspect ratio first.
+May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.</string>
+         </property>
+         <property name="text">
+          <string>Cover Fill</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QCheckBox" name="rotateRightBox">
+         <property name="toolTip">
+          <string>Rotate 2 page spreads in opposite direction than normal.</string>
+         </property>
+         <property name="text">
+          <string>Rotate Right</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="mangaBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;Enable right-to-left reading.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Right-to-left (manga)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QCheckBox" name="spreadShiftBox">
+         <property name="toolTip">
+          <string>Shift first page to opposite side in landscape for two page spread alignment</string>
+         </property>
+         <property name="text">
+          <string>Spread shift</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QCheckBox" name="croppingBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Disabled&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Disabled&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Margins&lt;br/&gt;&lt;/span&gt;Margins&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Margins + page numbers&lt;br/&gt;&lt;/span&gt;Margins +page numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Cropping mode</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
        <item row="8" column="0">
         <widget class="QCheckBox" name="jpegQualityBox">
          <property name="toolTip">
@@ -647,6 +746,133 @@ Higher values are larger and higher quality, and may resolve blank page issues.<
          </property>
         </widget>
        </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="outputSplit">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Automatic mode&lt;br/&gt;&lt;/span&gt;The output will be split automatically.&lt;/p&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Volume mode&lt;br/&gt;&lt;/span&gt;Every subdirectory will be considered as a separate volume.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Output split</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QCheckBox" name="metadataTitleBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Don't use metadata Title&lt;br/&gt;&lt;/span&gt;Write default title.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Add metadata Title to the default schema&lt;br/&gt;&lt;/span&gt;Write default title with Title from ComicInfo.xml or other embedded metadata.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Use metadata Title only&lt;br/&gt;&lt;/span&gt;Write Title from ComicInfo.xml or other embedded metadata.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Metadata Title</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QCheckBox" name="smartCoverCropBox">
+         <property name="toolTip">
+          <string>Attempt to crop main cover from wide image.</string>
+         </property>
+         <property name="text">
+          <string>Smart Cover Crop</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QCheckBox" name="rotateFirstBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the spread splitter option is partially checked,&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Rotate Last&lt;br/&gt;&lt;/span&gt;Put the rotated 2 page spread after the split spreads.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Rotate First&lt;br/&gt;&lt;/span&gt;Put the rotated 2 page spread before the split spreads.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Rotate First</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="mozJpegBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - JPEG&lt;br/&gt;&lt;/span&gt;Use JPEG files&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - force PNG&lt;br/&gt;&lt;/span&gt;Create PNG files instead JPEG for black and white images&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - mozJpeg&lt;br/&gt;&lt;/span&gt;10-20% smaller JPEG file, with the same image quality, but processing time multiplied by 2&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>JPEG/PNG/mozJpeg</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="2">
+        <widget class="QCheckBox" name="autoLevelBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, KCC maps the darkest pixel value to pure black (the black point.)&lt;/p&gt;&lt;p&gt;Extreme black point sets the black point to be the most common dark pixel value.&lt;/p&gt;&lt;p&gt;Useful when text is black but artwork is gray.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Extreme Black Point</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QCheckBox" name="forcePngRgbBox">
+         <property name="toolTip">
+          <string>Force full color images to be saved in lossless PNG format, dramatically increases the filesize.</string>
+         </property>
+         <property name="text">
+          <string>Force PNG RGB</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="upscaleBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Nothing&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will not be resized.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Stretching&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will be resized. Aspect ratio will be not preserved.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Upscaling&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will be resized. Aspect ratio will be preserved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Stretch/Upscale</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="borderBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Autodetection&lt;br/&gt;&lt;/span&gt;The color of margins fill will be detected automatically.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - White&lt;br/&gt;&lt;/span&gt;Margins will be untouched.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Black&lt;br/&gt;&lt;/span&gt;Margins will be filled with black color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>W/B margins</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="qualityBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - 4 panels&lt;br/&gt;&lt;/span&gt;Zoom each corner separately.&lt;/p&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - 2 panels&lt;br/&gt;&lt;/span&gt;Zoom only the top and bottom of the page.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - 4 high-quality panels&lt;br/&gt;&lt;/span&gt;Zoom each corner separately. Try to increase the quality of magnification. Check wiki for more details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Panel View 4/2/HQ</string>
+         </property>
+         <property name="tristate">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="pdfExtractBox">
+         <property name="toolTip">
+          <string>Use the PDF image extraction method from KCC 8 and earlier.
+
+Useful for really weird PDFs.</string>
+         </property>
+         <property name="text">
+          <string>PDF Legacy Extract</string>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="2">
         <widget class="QCheckBox" name="colorBox">
          <property name="toolTip">
@@ -654,6 +880,18 @@ Higher values are larger and higher quality, and may resolve blank page issues.<
          </property>
          <property name="text">
           <string>Color mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QCheckBox" name="pdfWidthBox">
+         <property name="toolTip">
+          <string>Render vector PDFs to device width instead of height.
+
+Useful if you plan to crop a little off the top and bottom to fill screen.</string>
+         </property>
+         <property name="text">
+          <string>PDF Width Render</string>
          </property>
         </widget>
        </item>
@@ -724,16 +962,13 @@ Higher values are larger and higher quality, and may resolve blank page issues.<
          </layout>
         </widget>
        </item>
-       <item row="7" column="0">
-        <widget class="QCheckBox" name="metadataTitleBox">
+       <item row="7" column="1">
+        <widget class="QCheckBox" name="chunkSizeCheckBox">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Don't use metadata Title&lt;br/&gt;&lt;/span&gt;Write default title.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Add metadata Title to the default schema&lt;br/&gt;&lt;/span&gt;Write default title with Title from ComicInfo.xml or other embedded metadata.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Use metadata Title only&lt;br/&gt;&lt;/span&gt;Write Title from ComicInfo.xml or other embedded metadata.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; text-decoration: underline;&quot;&gt;Unchecked&lt;br/&gt;&lt;/span&gt;Maximal output file size is 100 MB for Webtoon, 400 MB for others before split occurs.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; text-decoration: underline;&quot;&gt;Checked&lt;/span&gt;&lt;br/&gt;Output file size specified in &amp;quot;Chunk size MB&amp;quot; before split occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
-          <string>Metadata Title</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
+          <string>Chunk size</string>
          </property>
         </widget>
        </item>
@@ -750,238 +985,15 @@ Higher values are larger and higher quality, and may resolve blank page issues.<
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="pdfExtractBox">
+       <item row="12" column="0">
+        <widget class="QCheckBox" name="webpBox">
          <property name="toolTip">
-          <string>Use the PDF image extraction method from KCC 8 and earlier.
+          <string>Replace JPG with lossy WebP and PNG with lossless WebP. This includes the JPG Quality.
 
-Useful for really weird PDFs.</string>
+Ignored for Kindle EPUB/MOBI.</string>
          </property>
          <property name="text">
-          <string>PDF Legacy Extract</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QCheckBox" name="upscaleBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Nothing&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will not be resized.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Stretching&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will be resized. Aspect ratio will be not preserved.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Upscaling&lt;br/&gt;&lt;/span&gt;Images smaller than device resolution will be resized. Aspect ratio will be preserved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Stretch/Upscale</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QCheckBox" name="chunkSizeCheckBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; text-decoration: underline;&quot;&gt;Unchecked&lt;br/&gt;&lt;/span&gt;Maximal output file size is 100 MB for Webtoon, 400 MB for others before split occurs.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700; text-decoration: underline;&quot;&gt;Checked&lt;/span&gt;&lt;br/&gt;Output file size specified in &amp;quot;Chunk size MB&amp;quot; before split occurs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Chunk size</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QCheckBox" name="qualityBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - 4 panels&lt;br/&gt;&lt;/span&gt;Zoom each corner separately.&lt;/p&gt;&lt;p style='white-space:pre'&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - 2 panels&lt;br/&gt;&lt;/span&gt;Zoom only the top and bottom of the page.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - 4 high-quality panels&lt;br/&gt;&lt;/span&gt;Zoom each corner separately. Try to increase the quality of magnification. Check wiki for more details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Panel View 4/2/HQ</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QCheckBox" name="mozJpegBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - JPEG&lt;br/&gt;&lt;/span&gt;Use JPEG files&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - force PNG&lt;br/&gt;&lt;/span&gt;Create PNG files instead JPEG for black and white images&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - mozJpeg&lt;br/&gt;&lt;/span&gt;10-20% smaller JPEG file, with the same image quality, but processing time multiplied by 2&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>JPEG/PNG/mozJpeg</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLineEdit" name="titleEdit">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::FocusPolicy::ClickFocus</enum>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default Title&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="placeholderText">
-          <string>Default Title</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="2">
-        <widget class="QCheckBox" name="eraseRainbowBox">
-         <property name="toolTip">
-          <string>Erase rainbow effect on color eink screen by attenuating interfering frequencies</string>
-         </property>
-         <property name="text">
-          <string>Rainbow eraser</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QCheckBox" name="fileFusionBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Combines all selected files into a single file. (Helpful for combining chapters into volumes.)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>File Fusion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QCheckBox" name="coverFillBox">
-         <property name="toolTip">
-          <string>Resize cover to exact device resolution by center-cropping to aspect ratio first.
-May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.</string>
-         </property>
-         <property name="text">
-          <string>Cover Fill</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QCheckBox" name="rotateRightBox">
-         <property name="toolTip">
-          <string>Rotate 2 page spreads in opposite direction than normal.</string>
-         </property>
-         <property name="text">
-          <string>Rotate Right</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QCheckBox" name="gammaBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set a custom gamma correction.&lt;/p&gt;&lt;p&gt;1.0 is default (disabled).&lt;br/&gt;&amp;lt; 1.0 makes the image brighter.&lt;br/&gt;&amp;gt; 1.0 makes the image darker. &lt;/p&gt;&lt;p&gt;1.8 was the default in KCC 9.1.0 and earlier.&lt;/p&gt;&lt;p&gt;Use if you want to make midtones darker.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Custom gamma</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="2">
-        <widget class="QCheckBox" name="autoLevelBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, KCC maps the darkest pixel value to pure black (the black point.)&lt;/p&gt;&lt;p&gt;Extreme black point sets the black point to be the most common dark pixel value.&lt;/p&gt;&lt;p&gt;Useful when text is black but artwork is gray.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Extreme Black Point</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="2">
-        <widget class="QCheckBox" name="interPanelCropBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Disabled&lt;br/&gt;&lt;/span&gt;Disabled&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Horizontal&lt;br/&gt;&lt;/span&gt;Crop empty horizontal lines.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Both&lt;br/&gt;&lt;/span&gt;Crop empty horizontal and vertical lines.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Inter-panel crop</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="rotateBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Split&lt;br/&gt;&lt;/span&gt;Double page spreads will be cut into two separate pages.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Split and rotate&lt;br/&gt;&lt;/span&gt;Double page spreads will be displayed twice. First split and then rotated. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Rotate&lt;br/&gt;&lt;/span&gt;Double page spreads will be rotated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Spread splitter</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="authorEdit">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::FocusPolicy::ClickFocus</enum>
-         </property>
-         <property name="toolTip">
-          <string>Default Author is KCC</string>
-         </property>
-         <property name="placeholderText">
-          <string>Default Author</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QCheckBox" name="croppingBox">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Unchecked - Disabled&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Disabled&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Indeterminate - Margins&lt;br/&gt;&lt;/span&gt;Margins&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Checked - Margins + page numbers&lt;br/&gt;&lt;/span&gt;Margins +page numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Cropping mode</string>
-         </property>
-         <property name="tristate">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QCheckBox" name="pngLegacyBox">
-         <property name="toolTip">
-          <string>Use a more compatible 8 bit PNG instead of 4 bit.</string>
-         </property>
-         <property name="text">
-          <string>PNG Legacy Mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="2">
-        <widget class="QCheckBox" name="forcePngRgbBox">
-         <property name="toolTip">
-          <string>Force full color images to be saved in lossless PNG format, dramatically increases the filesize.</string>
-         </property>
-         <property name="text">
-          <string>Force PNG RGB</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QCheckBox" name="smartCoverCropBox">
-         <property name="toolTip">
-          <string>Attempt to crop main cover from wide image.</string>
-         </property>
-         <property name="text">
-          <string>Smart Cover Crop</string>
+          <string>WebP (experimental)</string>
          </property>
         </widget>
        </item>

--- a/gui/KCC.ui
+++ b/gui/KCC.ui
@@ -999,7 +999,7 @@ Useful if you plan to crop a little off the top and bottom to fill screen.</stri
          <property name="toolTip">
           <string>Replace JPG with lossy WebP and PNG with lossless WebP. This includes the JPG Quality.
 
-Ignored for Kindle EPUB/MOBI.</string>
+Ignored for Kindle EPUB/MOBI and all PDF.</string>
          </property>
          <property name="text">
           <string>WebP (experimental)</string>

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -359,6 +359,8 @@ class WorkerThread(QThread):
             options.forcepng = True
         elif GUI.mozJpegBox.checkState() == Qt.CheckState.Checked:
             options.mozjpeg = True
+        if GUI.webpBox.isChecked():
+            options.webp = True
         if GUI.pngLegacyBox.isChecked():
             options.pnglegacy = True
         if GUI.noQuantizeBox.isChecked():
@@ -1068,6 +1070,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
                                            'metadataTitleBox': GUI.metadataTitleBox.checkState(),
                                            'mozJpegBox': GUI.mozJpegBox.checkState(),
                                            'forcePngRgbBox': GUI.forcePngRgbBox.checkState(),
+                                           'webpBox': GUI.webpBox.checkState(),
                                            'pngLegacyBox': GUI.pngLegacyBox.checkState(),
                                            'noQuantizeBox': GUI.noQuantizeBox.checkState(),
                                            'jpegQualityBox': GUI.jpegQualityBox.checkState(),

--- a/kindlecomicconverter/KCC_ui.py
+++ b/kindlecomicconverter/KCC_ui.py
@@ -287,20 +287,154 @@ class Ui_mainWindow(object):
         self.gridLayout_2 = QGridLayout(self.optionWidget)
         self.gridLayout_2.setObjectName(u"gridLayout_2")
         self.gridLayout_2.setContentsMargins(0, 0, 0, 0)
-        self.rotateFirstBox = QCheckBox(self.optionWidget)
-        self.rotateFirstBox.setObjectName(u"rotateFirstBox")
+        self.noRotateBox = QCheckBox(self.optionWidget)
+        self.noRotateBox.setObjectName(u"noRotateBox")
 
-        self.gridLayout_2.addWidget(self.rotateFirstBox, 8, 1, 1, 1)
+        self.gridLayout_2.addWidget(self.noRotateBox, 6, 1, 1, 1)
+
+        self.maximizeStrips = QCheckBox(self.optionWidget)
+        self.maximizeStrips.setObjectName(u"maximizeStrips")
+
+        self.gridLayout_2.addWidget(self.maximizeStrips, 4, 1, 1, 1)
+
+        self.rotateBox = QCheckBox(self.optionWidget)
+        self.rotateBox.setObjectName(u"rotateBox")
+        self.rotateBox.setTristate(True)
+
+        self.gridLayout_2.addWidget(self.rotateBox, 1, 1, 1, 1)
+
+        self.pngLegacyBox = QCheckBox(self.optionWidget)
+        self.pngLegacyBox.setObjectName(u"pngLegacyBox")
+
+        self.gridLayout_2.addWidget(self.pngLegacyBox, 11, 0, 1, 1)
+
+        self.interPanelCropBox = QCheckBox(self.optionWidget)
+        self.interPanelCropBox.setObjectName(u"interPanelCropBox")
+        self.interPanelCropBox.setTristate(True)
+
+        self.gridLayout_2.addWidget(self.interPanelCropBox, 6, 2, 1, 1)
+
+        self.titleEdit = QLineEdit(self.optionWidget)
+        self.titleEdit.setObjectName(u"titleEdit")
+        sizePolicy4.setHeightForWidth(self.titleEdit.sizePolicy().hasHeightForWidth())
+        self.titleEdit.setSizePolicy(sizePolicy4)
+        self.titleEdit.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self.titleEdit.setClearButtonEnabled(False)
+
+        self.gridLayout_2.addWidget(self.titleEdit, 0, 0, 1, 1)
+
+        self.authorEdit = QLineEdit(self.optionWidget)
+        self.authorEdit.setObjectName(u"authorEdit")
+        sizePolicy4.setHeightForWidth(self.authorEdit.sizePolicy().hasHeightForWidth())
+        self.authorEdit.setSizePolicy(sizePolicy4)
+        self.authorEdit.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self.authorEdit.setClearButtonEnabled(False)
+
+        self.gridLayout_2.addWidget(self.authorEdit, 0, 1, 1, 1)
+
+        self.webtoonBox = QCheckBox(self.optionWidget)
+        self.webtoonBox.setObjectName(u"webtoonBox")
+
+        self.gridLayout_2.addWidget(self.webtoonBox, 2, 0, 1, 1)
+
+        self.fileFusionBox = QCheckBox(self.optionWidget)
+        self.fileFusionBox.setObjectName(u"fileFusionBox")
+
+        self.gridLayout_2.addWidget(self.fileFusionBox, 6, 0, 1, 1)
+
+        self.deleteBox = QCheckBox(self.optionWidget)
+        self.deleteBox.setObjectName(u"deleteBox")
+
+        self.gridLayout_2.addWidget(self.deleteBox, 5, 1, 1, 1)
+
+        self.gammaBox = QCheckBox(self.optionWidget)
+        self.gammaBox.setObjectName(u"gammaBox")
+
+        self.gridLayout_2.addWidget(self.gammaBox, 2, 2, 1, 1)
+
+        self.noQuantizeBox = QCheckBox(self.optionWidget)
+        self.noQuantizeBox.setObjectName(u"noQuantizeBox")
+
+        self.gridLayout_2.addWidget(self.noQuantizeBox, 10, 2, 1, 1)
+
+        self.eraseRainbowBox = QCheckBox(self.optionWidget)
+        self.eraseRainbowBox.setObjectName(u"eraseRainbowBox")
+
+        self.gridLayout_2.addWidget(self.eraseRainbowBox, 7, 2, 1, 1)
+
+        self.coverFillBox = QCheckBox(self.optionWidget)
+        self.coverFillBox.setObjectName(u"coverFillBox")
+
+        self.gridLayout_2.addWidget(self.coverFillBox, 9, 1, 1, 1)
+
+        self.rotateRightBox = QCheckBox(self.optionWidget)
+        self.rotateRightBox.setObjectName(u"rotateRightBox")
+
+        self.gridLayout_2.addWidget(self.rotateRightBox, 10, 1, 1, 1)
+
+        self.mangaBox = QCheckBox(self.optionWidget)
+        self.mangaBox.setObjectName(u"mangaBox")
+
+        self.gridLayout_2.addWidget(self.mangaBox, 1, 0, 1, 1)
+
+        self.spreadShiftBox = QCheckBox(self.optionWidget)
+        self.spreadShiftBox.setObjectName(u"spreadShiftBox")
+
+        self.gridLayout_2.addWidget(self.spreadShiftBox, 5, 0, 1, 1)
+
+        self.croppingBox = QCheckBox(self.optionWidget)
+        self.croppingBox.setObjectName(u"croppingBox")
+        self.croppingBox.setTristate(True)
+
+        self.gridLayout_2.addWidget(self.croppingBox, 4, 2, 1, 1)
+
+        self.jpegQualityBox = QCheckBox(self.optionWidget)
+        self.jpegQualityBox.setObjectName(u"jpegQualityBox")
+
+        self.gridLayout_2.addWidget(self.jpegQualityBox, 8, 0, 1, 1)
 
         self.outputSplit = QCheckBox(self.optionWidget)
         self.outputSplit.setObjectName(u"outputSplit")
 
         self.gridLayout_2.addWidget(self.outputSplit, 3, 1, 1, 1)
 
-        self.pdfWidthBox = QCheckBox(self.optionWidget)
-        self.pdfWidthBox.setObjectName(u"pdfWidthBox")
+        self.metadataTitleBox = QCheckBox(self.optionWidget)
+        self.metadataTitleBox.setObjectName(u"metadataTitleBox")
+        self.metadataTitleBox.setTristate(True)
 
-        self.gridLayout_2.addWidget(self.pdfWidthBox, 10, 0, 1, 1)
+        self.gridLayout_2.addWidget(self.metadataTitleBox, 7, 0, 1, 1)
+
+        self.smartCoverCropBox = QCheckBox(self.optionWidget)
+        self.smartCoverCropBox.setObjectName(u"smartCoverCropBox")
+
+        self.gridLayout_2.addWidget(self.smartCoverCropBox, 11, 1, 1, 1)
+
+        self.rotateFirstBox = QCheckBox(self.optionWidget)
+        self.rotateFirstBox.setObjectName(u"rotateFirstBox")
+
+        self.gridLayout_2.addWidget(self.rotateFirstBox, 8, 1, 1, 1)
+
+        self.mozJpegBox = QCheckBox(self.optionWidget)
+        self.mozJpegBox.setObjectName(u"mozJpegBox")
+        self.mozJpegBox.setTristate(True)
+
+        self.gridLayout_2.addWidget(self.mozJpegBox, 4, 0, 1, 1)
+
+        self.autoLevelBox = QCheckBox(self.optionWidget)
+        self.autoLevelBox.setObjectName(u"autoLevelBox")
+
+        self.gridLayout_2.addWidget(self.autoLevelBox, 8, 2, 1, 1)
+
+        self.forcePngRgbBox = QCheckBox(self.optionWidget)
+        self.forcePngRgbBox.setObjectName(u"forcePngRgbBox")
+
+        self.gridLayout_2.addWidget(self.forcePngRgbBox, 11, 2, 1, 1)
+
+        self.upscaleBox = QCheckBox(self.optionWidget)
+        self.upscaleBox.setObjectName(u"upscaleBox")
+        self.upscaleBox.setTristate(True)
+
+        self.gridLayout_2.addWidget(self.upscaleBox, 2, 1, 1, 1)
 
         self.borderBox = QCheckBox(self.optionWidget)
         self.borderBox.setObjectName(u"borderBox")
@@ -308,50 +442,26 @@ class Ui_mainWindow(object):
 
         self.gridLayout_2.addWidget(self.borderBox, 3, 0, 1, 1)
 
-        self.deleteBox = QCheckBox(self.optionWidget)
-        self.deleteBox.setObjectName(u"deleteBox")
+        self.qualityBox = QCheckBox(self.optionWidget)
+        self.qualityBox.setObjectName(u"qualityBox")
+        self.qualityBox.setTristate(True)
 
-        self.gridLayout_2.addWidget(self.deleteBox, 5, 1, 1, 1)
+        self.gridLayout_2.addWidget(self.qualityBox, 1, 2, 1, 1)
 
-        self.spreadShiftBox = QCheckBox(self.optionWidget)
-        self.spreadShiftBox.setObjectName(u"spreadShiftBox")
+        self.pdfExtractBox = QCheckBox(self.optionWidget)
+        self.pdfExtractBox.setObjectName(u"pdfExtractBox")
 
-        self.gridLayout_2.addWidget(self.spreadShiftBox, 5, 0, 1, 1)
-
-        self.maximizeStrips = QCheckBox(self.optionWidget)
-        self.maximizeStrips.setObjectName(u"maximizeStrips")
-
-        self.gridLayout_2.addWidget(self.maximizeStrips, 4, 1, 1, 1)
-
-        self.webtoonBox = QCheckBox(self.optionWidget)
-        self.webtoonBox.setObjectName(u"webtoonBox")
-
-        self.gridLayout_2.addWidget(self.webtoonBox, 2, 0, 1, 1)
-
-        self.noRotateBox = QCheckBox(self.optionWidget)
-        self.noRotateBox.setObjectName(u"noRotateBox")
-
-        self.gridLayout_2.addWidget(self.noRotateBox, 6, 1, 1, 1)
-
-        self.mangaBox = QCheckBox(self.optionWidget)
-        self.mangaBox.setObjectName(u"mangaBox")
-
-        self.gridLayout_2.addWidget(self.mangaBox, 1, 0, 1, 1)
-
-        self.noQuantizeBox = QCheckBox(self.optionWidget)
-        self.noQuantizeBox.setObjectName(u"noQuantizeBox")
-
-        self.gridLayout_2.addWidget(self.noQuantizeBox, 10, 2, 1, 1)
-
-        self.jpegQualityBox = QCheckBox(self.optionWidget)
-        self.jpegQualityBox.setObjectName(u"jpegQualityBox")
-
-        self.gridLayout_2.addWidget(self.jpegQualityBox, 8, 0, 1, 1)
+        self.gridLayout_2.addWidget(self.pdfExtractBox, 9, 0, 1, 1)
 
         self.colorBox = QCheckBox(self.optionWidget)
         self.colorBox.setObjectName(u"colorBox")
 
         self.gridLayout_2.addWidget(self.colorBox, 3, 2, 1, 1)
+
+        self.pdfWidthBox = QCheckBox(self.optionWidget)
+        self.pdfWidthBox.setObjectName(u"pdfWidthBox")
+
+        self.gridLayout_2.addWidget(self.pdfWidthBox, 10, 0, 1, 1)
 
         self.disableProcessingBox = QCheckBox(self.optionWidget)
         self.disableProcessingBox.setObjectName(u"disableProcessingBox")
@@ -381,11 +491,10 @@ class Ui_mainWindow(object):
 
         self.gridLayout_2.addWidget(self.outputFolderWidget, 0, 2, 1, 1)
 
-        self.metadataTitleBox = QCheckBox(self.optionWidget)
-        self.metadataTitleBox.setObjectName(u"metadataTitleBox")
-        self.metadataTitleBox.setTristate(True)
+        self.chunkSizeCheckBox = QCheckBox(self.optionWidget)
+        self.chunkSizeCheckBox.setObjectName(u"chunkSizeCheckBox")
 
-        self.gridLayout_2.addWidget(self.metadataTitleBox, 7, 0, 1, 1)
+        self.gridLayout_2.addWidget(self.chunkSizeCheckBox, 7, 1, 1, 1)
 
         self.autocontrastBox = QCheckBox(self.optionWidget)
         self.autocontrastBox.setObjectName(u"autocontrastBox")
@@ -393,114 +502,10 @@ class Ui_mainWindow(object):
 
         self.gridLayout_2.addWidget(self.autocontrastBox, 9, 2, 1, 1)
 
-        self.pdfExtractBox = QCheckBox(self.optionWidget)
-        self.pdfExtractBox.setObjectName(u"pdfExtractBox")
+        self.webpBox = QCheckBox(self.optionWidget)
+        self.webpBox.setObjectName(u"webpBox")
 
-        self.gridLayout_2.addWidget(self.pdfExtractBox, 9, 0, 1, 1)
-
-        self.upscaleBox = QCheckBox(self.optionWidget)
-        self.upscaleBox.setObjectName(u"upscaleBox")
-        self.upscaleBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.upscaleBox, 2, 1, 1, 1)
-
-        self.chunkSizeCheckBox = QCheckBox(self.optionWidget)
-        self.chunkSizeCheckBox.setObjectName(u"chunkSizeCheckBox")
-
-        self.gridLayout_2.addWidget(self.chunkSizeCheckBox, 7, 1, 1, 1)
-
-        self.qualityBox = QCheckBox(self.optionWidget)
-        self.qualityBox.setObjectName(u"qualityBox")
-        self.qualityBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.qualityBox, 1, 2, 1, 1)
-
-        self.mozJpegBox = QCheckBox(self.optionWidget)
-        self.mozJpegBox.setObjectName(u"mozJpegBox")
-        self.mozJpegBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.mozJpegBox, 4, 0, 1, 1)
-
-        self.titleEdit = QLineEdit(self.optionWidget)
-        self.titleEdit.setObjectName(u"titleEdit")
-        sizePolicy4.setHeightForWidth(self.titleEdit.sizePolicy().hasHeightForWidth())
-        self.titleEdit.setSizePolicy(sizePolicy4)
-        self.titleEdit.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
-        self.titleEdit.setClearButtonEnabled(False)
-
-        self.gridLayout_2.addWidget(self.titleEdit, 0, 0, 1, 1)
-
-        self.eraseRainbowBox = QCheckBox(self.optionWidget)
-        self.eraseRainbowBox.setObjectName(u"eraseRainbowBox")
-
-        self.gridLayout_2.addWidget(self.eraseRainbowBox, 7, 2, 1, 1)
-
-        self.fileFusionBox = QCheckBox(self.optionWidget)
-        self.fileFusionBox.setObjectName(u"fileFusionBox")
-
-        self.gridLayout_2.addWidget(self.fileFusionBox, 6, 0, 1, 1)
-
-        self.coverFillBox = QCheckBox(self.optionWidget)
-        self.coverFillBox.setObjectName(u"coverFillBox")
-
-        self.gridLayout_2.addWidget(self.coverFillBox, 9, 1, 1, 1)
-
-        self.rotateRightBox = QCheckBox(self.optionWidget)
-        self.rotateRightBox.setObjectName(u"rotateRightBox")
-
-        self.gridLayout_2.addWidget(self.rotateRightBox, 10, 1, 1, 1)
-
-        self.gammaBox = QCheckBox(self.optionWidget)
-        self.gammaBox.setObjectName(u"gammaBox")
-
-        self.gridLayout_2.addWidget(self.gammaBox, 2, 2, 1, 1)
-
-        self.autoLevelBox = QCheckBox(self.optionWidget)
-        self.autoLevelBox.setObjectName(u"autoLevelBox")
-
-        self.gridLayout_2.addWidget(self.autoLevelBox, 8, 2, 1, 1)
-
-        self.interPanelCropBox = QCheckBox(self.optionWidget)
-        self.interPanelCropBox.setObjectName(u"interPanelCropBox")
-        self.interPanelCropBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.interPanelCropBox, 6, 2, 1, 1)
-
-        self.rotateBox = QCheckBox(self.optionWidget)
-        self.rotateBox.setObjectName(u"rotateBox")
-        self.rotateBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.rotateBox, 1, 1, 1, 1)
-
-        self.authorEdit = QLineEdit(self.optionWidget)
-        self.authorEdit.setObjectName(u"authorEdit")
-        sizePolicy4.setHeightForWidth(self.authorEdit.sizePolicy().hasHeightForWidth())
-        self.authorEdit.setSizePolicy(sizePolicy4)
-        self.authorEdit.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
-        self.authorEdit.setClearButtonEnabled(False)
-
-        self.gridLayout_2.addWidget(self.authorEdit, 0, 1, 1, 1)
-
-        self.croppingBox = QCheckBox(self.optionWidget)
-        self.croppingBox.setObjectName(u"croppingBox")
-        self.croppingBox.setTristate(True)
-
-        self.gridLayout_2.addWidget(self.croppingBox, 4, 2, 1, 1)
-
-        self.pngLegacyBox = QCheckBox(self.optionWidget)
-        self.pngLegacyBox.setObjectName(u"pngLegacyBox")
-
-        self.gridLayout_2.addWidget(self.pngLegacyBox, 11, 0, 1, 1)
-
-        self.forcePngRgbBox = QCheckBox(self.optionWidget)
-        self.forcePngRgbBox.setObjectName(u"forcePngRgbBox")
-
-        self.gridLayout_2.addWidget(self.forcePngRgbBox, 11, 2, 1, 1)
-
-        self.smartCoverCropBox = QCheckBox(self.optionWidget)
-        self.smartCoverCropBox.setObjectName(u"smartCoverCropBox")
-
-        self.gridLayout_2.addWidget(self.smartCoverCropBox, 11, 1, 1, 1)
+        self.gridLayout_2.addWidget(self.webpBox, 12, 0, 1, 1)
 
 
         self.gridLayout.addWidget(self.optionWidget, 5, 0, 1, 2)
@@ -655,47 +660,49 @@ class Ui_mainWindow(object):
         self.chunkSizeLabel.setText(QCoreApplication.translate("mainWindow", u"Chunk size MB:", None))
         self.chunkSizeWarnLabel.setText(QCoreApplication.translate("mainWindow", u"Greater than default may cause performance issues on older ereaders.", None))
 #if QT_CONFIG(tooltip)
-        self.rotateFirstBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>When the spread splitter option is partially checked,</p><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Rotate Last<br/></span>Put the rotated 2 page spread after the split spreads.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Rotate First<br/></span>Put the rotated 2 page spread before the split spreads.</p></body></html>", None))
+        self.noRotateBox.setToolTip(QCoreApplication.translate("mainWindow", u"Do not rotate double page spreads in spread splitter option.", None))
 #endif // QT_CONFIG(tooltip)
-        self.rotateFirstBox.setText(QCoreApplication.translate("mainWindow", u"Rotate First", None))
-#if QT_CONFIG(tooltip)
-        self.outputSplit.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Automatic mode<br/></span>The output will be split automatically.</p><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Checked - Volume mode<br/></span>Every subdirectory will be considered as a separate volume.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.outputSplit.setText(QCoreApplication.translate("mainWindow", u"Output split", None))
-#if QT_CONFIG(tooltip)
-        self.pdfWidthBox.setToolTip(QCoreApplication.translate("mainWindow", u"Render vector PDFs to device width instead of height.\n"
-"\n"
-"Useful if you plan to crop a little off the top and bottom to fill screen.", None))
-#endif // QT_CONFIG(tooltip)
-        self.pdfWidthBox.setText(QCoreApplication.translate("mainWindow", u"PDF Width Render", None))
-#if QT_CONFIG(tooltip)
-        self.borderBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Autodetection<br/></span>The color of margins fill will be detected automatically.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - White<br/></span>Margins will be untouched.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Black<br/></span>Margins will be filled with black color.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.borderBox.setText(QCoreApplication.translate("mainWindow", u"W/B margins", None))
-#if QT_CONFIG(tooltip)
-        self.deleteBox.setToolTip(QCoreApplication.translate("mainWindow", u"Delete input file(s) or directory. It's not recoverable!", None))
-#endif // QT_CONFIG(tooltip)
-        self.deleteBox.setText(QCoreApplication.translate("mainWindow", u"Delete input", None))
-#if QT_CONFIG(tooltip)
-        self.spreadShiftBox.setToolTip(QCoreApplication.translate("mainWindow", u"Shift first page to opposite side in landscape for two page spread alignment", None))
-#endif // QT_CONFIG(tooltip)
-        self.spreadShiftBox.setText(QCoreApplication.translate("mainWindow", u"Spread shift", None))
+        self.noRotateBox.setText(QCoreApplication.translate("mainWindow", u"No rotate", None))
 #if QT_CONFIG(tooltip)
         self.maximizeStrips.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - 1x4<br/></span>Keep format 1x4 panels strips.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - 2x2<br/></span>Turn 1x4 strips to 2x2 to maximize screen usage.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.maximizeStrips.setText(QCoreApplication.translate("mainWindow", u"1x4 to 2x2 strips", None))
 #if QT_CONFIG(tooltip)
+        self.rotateBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Split<br/></span>Double page spreads will be cut into two separate pages.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Split and rotate<br/></span>Double page spreads will be displayed twice. First split and then rotated. </p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Rotate<br/></span>Double page spreads will be rotated.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.rotateBox.setText(QCoreApplication.translate("mainWindow", u"Spread splitter", None))
+#if QT_CONFIG(tooltip)
+        self.pngLegacyBox.setToolTip(QCoreApplication.translate("mainWindow", u"Use a more compatible 8 bit PNG instead of 4 bit.", None))
+#endif // QT_CONFIG(tooltip)
+        self.pngLegacyBox.setText(QCoreApplication.translate("mainWindow", u"PNG Legacy Mode", None))
+#if QT_CONFIG(tooltip)
+        self.interPanelCropBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Disabled<br/></span>Disabled</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Horizontal<br/></span>Crop empty horizontal lines.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Both<br/></span>Crop empty horizontal and vertical lines.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.interPanelCropBox.setText(QCoreApplication.translate("mainWindow", u"Inter-panel crop", None))
+#if QT_CONFIG(tooltip)
+        self.titleEdit.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Default Title</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.titleEdit.setPlaceholderText(QCoreApplication.translate("mainWindow", u"Default Title", None))
+#if QT_CONFIG(tooltip)
+        self.authorEdit.setToolTip(QCoreApplication.translate("mainWindow", u"Default Author is KCC", None))
+#endif // QT_CONFIG(tooltip)
+        self.authorEdit.setPlaceholderText(QCoreApplication.translate("mainWindow", u"Default Author", None))
+#if QT_CONFIG(tooltip)
         self.webtoonBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'>Enable special parsing mode for Korean Webtoons.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.webtoonBox.setText(QCoreApplication.translate("mainWindow", u"Webtoon mode", None))
 #if QT_CONFIG(tooltip)
-        self.noRotateBox.setToolTip(QCoreApplication.translate("mainWindow", u"Do not rotate double page spreads in spread splitter option.", None))
+        self.fileFusionBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Combines all selected files into a single file. (Helpful for combining chapters into volumes.)</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.noRotateBox.setText(QCoreApplication.translate("mainWindow", u"No rotate", None))
+        self.fileFusionBox.setText(QCoreApplication.translate("mainWindow", u"File Fusion", None))
 #if QT_CONFIG(tooltip)
-        self.mangaBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'>Enable right-to-left reading.</p></body></html>", None))
+        self.deleteBox.setToolTip(QCoreApplication.translate("mainWindow", u"Delete input file(s) or directory. It's not recoverable!", None))
 #endif // QT_CONFIG(tooltip)
-        self.mangaBox.setText(QCoreApplication.translate("mainWindow", u"Right-to-left (manga)", None))
+        self.deleteBox.setText(QCoreApplication.translate("mainWindow", u"Delete input", None))
+#if QT_CONFIG(tooltip)
+        self.gammaBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Set a custom gamma correction.</p><p>1.0 is default (disabled).<br/>&lt; 1.0 makes the image brighter.<br/>&gt; 1.0 makes the image darker. </p><p>1.8 was the default in KCC 9.1.0 and earlier.</p><p>Use if you want to make midtones darker.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.gammaBox.setText(QCoreApplication.translate("mainWindow", u"Custom gamma", None))
 #if QT_CONFIG(tooltip)
         self.noQuantizeBox.setToolTip(QCoreApplication.translate("mainWindow", u"Don't quantize PNG images to 16 colors (4 bit)\n"
 "\n"
@@ -705,6 +712,31 @@ class Ui_mainWindow(object):
 #endif // QT_CONFIG(tooltip)
         self.noQuantizeBox.setText(QCoreApplication.translate("mainWindow", u"No Quantize", None))
 #if QT_CONFIG(tooltip)
+        self.eraseRainbowBox.setToolTip(QCoreApplication.translate("mainWindow", u"Erase rainbow effect on color eink screen by attenuating interfering frequencies", None))
+#endif // QT_CONFIG(tooltip)
+        self.eraseRainbowBox.setText(QCoreApplication.translate("mainWindow", u"Rainbow eraser", None))
+#if QT_CONFIG(tooltip)
+        self.coverFillBox.setToolTip(QCoreApplication.translate("mainWindow", u"Resize cover to exact device resolution by center-cropping to aspect ratio first.\n"
+"May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.", None))
+#endif // QT_CONFIG(tooltip)
+        self.coverFillBox.setText(QCoreApplication.translate("mainWindow", u"Cover Fill", None))
+#if QT_CONFIG(tooltip)
+        self.rotateRightBox.setToolTip(QCoreApplication.translate("mainWindow", u"Rotate 2 page spreads in opposite direction than normal.", None))
+#endif // QT_CONFIG(tooltip)
+        self.rotateRightBox.setText(QCoreApplication.translate("mainWindow", u"Rotate Right", None))
+#if QT_CONFIG(tooltip)
+        self.mangaBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'>Enable right-to-left reading.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.mangaBox.setText(QCoreApplication.translate("mainWindow", u"Right-to-left (manga)", None))
+#if QT_CONFIG(tooltip)
+        self.spreadShiftBox.setToolTip(QCoreApplication.translate("mainWindow", u"Shift first page to opposite side in landscape for two page spread alignment", None))
+#endif // QT_CONFIG(tooltip)
+        self.spreadShiftBox.setText(QCoreApplication.translate("mainWindow", u"Spread shift", None))
+#if QT_CONFIG(tooltip)
+        self.croppingBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Disabled</span></p><p>Disabled</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Margins<br/></span>Margins</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Margins + page numbers<br/></span>Margins +page numbers</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.croppingBox.setText(QCoreApplication.translate("mainWindow", u"Cropping mode", None))
+#if QT_CONFIG(tooltip)
         self.jpegQualityBox.setToolTip(QCoreApplication.translate("mainWindow", u"The JPEG quality, on a scale from 0 (worst) to 95 (best). \n"
 "\n"
 "Default is 85 for most devices besides Kindle Scribe and Colorsoft, which are 90.\n"
@@ -713,9 +745,61 @@ class Ui_mainWindow(object):
 #endif // QT_CONFIG(tooltip)
         self.jpegQualityBox.setText(QCoreApplication.translate("mainWindow", u"Custom JPEG Quality", None))
 #if QT_CONFIG(tooltip)
+        self.outputSplit.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Automatic mode<br/></span>The output will be split automatically.</p><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Checked - Volume mode<br/></span>Every subdirectory will be considered as a separate volume.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.outputSplit.setText(QCoreApplication.translate("mainWindow", u"Output split", None))
+#if QT_CONFIG(tooltip)
+        self.metadataTitleBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Don't use metadata Title<br/></span>Write default title.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Add metadata Title to the default schema<br/></span>Write default title with Title from ComicInfo.xml or other embedded metadata.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Use metadata Title only<br/></span>Write Title from ComicInfo.xml or other embedded metadata.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.metadataTitleBox.setText(QCoreApplication.translate("mainWindow", u"Metadata Title", None))
+#if QT_CONFIG(tooltip)
+        self.smartCoverCropBox.setToolTip(QCoreApplication.translate("mainWindow", u"Attempt to crop main cover from wide image.", None))
+#endif // QT_CONFIG(tooltip)
+        self.smartCoverCropBox.setText(QCoreApplication.translate("mainWindow", u"Smart Cover Crop", None))
+#if QT_CONFIG(tooltip)
+        self.rotateFirstBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>When the spread splitter option is partially checked,</p><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Rotate Last<br/></span>Put the rotated 2 page spread after the split spreads.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Rotate First<br/></span>Put the rotated 2 page spread before the split spreads.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.rotateFirstBox.setText(QCoreApplication.translate("mainWindow", u"Rotate First", None))
+#if QT_CONFIG(tooltip)
+        self.mozJpegBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - JPEG<br/></span>Use JPEG files</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - force PNG<br/></span>Create PNG files instead JPEG for black and white images</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - mozJpeg<br/></span>10-20% smaller JPEG file, with the same image quality, but processing time multiplied by 2</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.mozJpegBox.setText(QCoreApplication.translate("mainWindow", u"JPEG/PNG/mozJpeg", None))
+#if QT_CONFIG(tooltip)
+        self.autoLevelBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>By default, KCC maps the darkest pixel value to pure black (the black point.)</p><p>Extreme black point sets the black point to be the most common dark pixel value.</p><p>Useful when text is black but artwork is gray.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.autoLevelBox.setText(QCoreApplication.translate("mainWindow", u"Extreme Black Point", None))
+#if QT_CONFIG(tooltip)
+        self.forcePngRgbBox.setToolTip(QCoreApplication.translate("mainWindow", u"Force full color images to be saved in lossless PNG format, dramatically increases the filesize.", None))
+#endif // QT_CONFIG(tooltip)
+        self.forcePngRgbBox.setText(QCoreApplication.translate("mainWindow", u"Force PNG RGB", None))
+#if QT_CONFIG(tooltip)
+        self.upscaleBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Nothing<br/></span>Images smaller than device resolution will not be resized.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Stretching<br/></span>Images smaller than device resolution will be resized. Aspect ratio will be not preserved.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Upscaling<br/></span>Images smaller than device resolution will be resized. Aspect ratio will be preserved.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.upscaleBox.setText(QCoreApplication.translate("mainWindow", u"Stretch/Upscale", None))
+#if QT_CONFIG(tooltip)
+        self.borderBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Autodetection<br/></span>The color of margins fill will be detected automatically.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - White<br/></span>Margins will be untouched.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Black<br/></span>Margins will be filled with black color.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.borderBox.setText(QCoreApplication.translate("mainWindow", u"W/B margins", None))
+#if QT_CONFIG(tooltip)
+        self.qualityBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - 4 panels<br/></span>Zoom each corner separately.</p><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - 2 panels<br/></span>Zoom only the top and bottom of the page.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - 4 high-quality panels<br/></span>Zoom each corner separately. Try to increase the quality of magnification. Check wiki for more details.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.qualityBox.setText(QCoreApplication.translate("mainWindow", u"Panel View 4/2/HQ", None))
+#if QT_CONFIG(tooltip)
+        self.pdfExtractBox.setToolTip(QCoreApplication.translate("mainWindow", u"Use the PDF image extraction method from KCC 8 and earlier.\n"
+"\n"
+"Useful for really weird PDFs.", None))
+#endif // QT_CONFIG(tooltip)
+        self.pdfExtractBox.setText(QCoreApplication.translate("mainWindow", u"PDF Legacy Extract", None))
+#if QT_CONFIG(tooltip)
         self.colorBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'>Disable conversion to grayscale.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.colorBox.setText(QCoreApplication.translate("mainWindow", u"Color mode", None))
+#if QT_CONFIG(tooltip)
+        self.pdfWidthBox.setToolTip(QCoreApplication.translate("mainWindow", u"Render vector PDFs to device width instead of height.\n"
+"\n"
+"Useful if you plan to crop a little off the top and bottom to fill screen.", None))
+#endif // QT_CONFIG(tooltip)
+        self.pdfWidthBox.setText(QCoreApplication.translate("mainWindow", u"PDF Width Render", None))
 #if QT_CONFIG(tooltip)
         self.disableProcessingBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'>Do not process any image, ignore profile and processing options.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
@@ -729,92 +813,19 @@ class Ui_mainWindow(object):
 #endif // QT_CONFIG(tooltip)
         self.defaultOutputFolderButton.setText("")
 #if QT_CONFIG(tooltip)
-        self.metadataTitleBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Don't use metadata Title<br/></span>Write default title.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Add metadata Title to the default schema<br/></span>Write default title with Title from ComicInfo.xml or other embedded metadata.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Use metadata Title only<br/></span>Write Title from ComicInfo.xml or other embedded metadata.</p></body></html>", None))
+        self.chunkSizeCheckBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:700; text-decoration: underline;\">Unchecked<br/></span>Maximal output file size is 100 MB for Webtoon, 400 MB for others before split occurs.</p><p><span style=\" font-weight:700; text-decoration: underline;\">Checked</span><br/>Output file size specified in &quot;Chunk size MB&quot; before split occurs.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
-        self.metadataTitleBox.setText(QCoreApplication.translate("mainWindow", u"Metadata Title", None))
+        self.chunkSizeCheckBox.setText(QCoreApplication.translate("mainWindow", u"Chunk size", None))
 #if QT_CONFIG(tooltip)
         self.autocontrastBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - BW only<br/></span>Only autocontrast bw pages. Ignored for pages where near blacks or whites don't exist.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Disabled<br/></span>Disable autocontrast</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - BW and Color<br/></span>BW and color images will be autocontrasted. Ignored for pages where near blacks or whites don't exist.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.autocontrastBox.setText(QCoreApplication.translate("mainWindow", u"Autocontrast", None))
 #if QT_CONFIG(tooltip)
-        self.pdfExtractBox.setToolTip(QCoreApplication.translate("mainWindow", u"Use the PDF image extraction method from KCC 8 and earlier.\n"
+        self.webpBox.setToolTip(QCoreApplication.translate("mainWindow", u"Replace JPG with lossy WebP and PNG with lossless WebP. This includes the JPG Quality.\n"
 "\n"
-"Useful for really weird PDFs.", None))
+"Ignored for Kindle EPUB/MOBI.", None))
 #endif // QT_CONFIG(tooltip)
-        self.pdfExtractBox.setText(QCoreApplication.translate("mainWindow", u"PDF Legacy Extract", None))
-#if QT_CONFIG(tooltip)
-        self.upscaleBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Nothing<br/></span>Images smaller than device resolution will not be resized.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Stretching<br/></span>Images smaller than device resolution will be resized. Aspect ratio will be not preserved.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Upscaling<br/></span>Images smaller than device resolution will be resized. Aspect ratio will be preserved.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.upscaleBox.setText(QCoreApplication.translate("mainWindow", u"Stretch/Upscale", None))
-#if QT_CONFIG(tooltip)
-        self.chunkSizeCheckBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:700; text-decoration: underline;\">Unchecked<br/></span>Maximal output file size is 100 MB for Webtoon, 400 MB for others before split occurs.</p><p><span style=\" font-weight:700; text-decoration: underline;\">Checked</span><br/>Output file size specified in &quot;Chunk size MB&quot; before split occurs.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.chunkSizeCheckBox.setText(QCoreApplication.translate("mainWindow", u"Chunk size", None))
-#if QT_CONFIG(tooltip)
-        self.qualityBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - 4 panels<br/></span>Zoom each corner separately.</p><p style='white-space:pre'><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - 2 panels<br/></span>Zoom only the top and bottom of the page.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - 4 high-quality panels<br/></span>Zoom each corner separately. Try to increase the quality of magnification. Check wiki for more details.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.qualityBox.setText(QCoreApplication.translate("mainWindow", u"Panel View 4/2/HQ", None))
-#if QT_CONFIG(tooltip)
-        self.mozJpegBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - JPEG<br/></span>Use JPEG files</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - force PNG<br/></span>Create PNG files instead JPEG for black and white images</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - mozJpeg<br/></span>10-20% smaller JPEG file, with the same image quality, but processing time multiplied by 2</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.mozJpegBox.setText(QCoreApplication.translate("mainWindow", u"JPEG/PNG/mozJpeg", None))
-#if QT_CONFIG(tooltip)
-        self.titleEdit.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Default Title</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.titleEdit.setPlaceholderText(QCoreApplication.translate("mainWindow", u"Default Title", None))
-#if QT_CONFIG(tooltip)
-        self.eraseRainbowBox.setToolTip(QCoreApplication.translate("mainWindow", u"Erase rainbow effect on color eink screen by attenuating interfering frequencies", None))
-#endif // QT_CONFIG(tooltip)
-        self.eraseRainbowBox.setText(QCoreApplication.translate("mainWindow", u"Rainbow eraser", None))
-#if QT_CONFIG(tooltip)
-        self.fileFusionBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Combines all selected files into a single file. (Helpful for combining chapters into volumes.)</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.fileFusionBox.setText(QCoreApplication.translate("mainWindow", u"File Fusion", None))
-#if QT_CONFIG(tooltip)
-        self.coverFillBox.setToolTip(QCoreApplication.translate("mainWindow", u"Resize cover to exact device resolution by center-cropping to aspect ratio first.\n"
-"May crop top/bottom or left/right depending on source aspect ratio. Not implemented for Kindle Scribe.", None))
-#endif // QT_CONFIG(tooltip)
-        self.coverFillBox.setText(QCoreApplication.translate("mainWindow", u"Cover Fill", None))
-#if QT_CONFIG(tooltip)
-        self.rotateRightBox.setToolTip(QCoreApplication.translate("mainWindow", u"Rotate 2 page spreads in opposite direction than normal.", None))
-#endif // QT_CONFIG(tooltip)
-        self.rotateRightBox.setText(QCoreApplication.translate("mainWindow", u"Rotate Right", None))
-#if QT_CONFIG(tooltip)
-        self.gammaBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>Set a custom gamma correction.</p><p>1.0 is default (disabled).<br/>&lt; 1.0 makes the image brighter.<br/>&gt; 1.0 makes the image darker. </p><p>1.8 was the default in KCC 9.1.0 and earlier.</p><p>Use if you want to make midtones darker.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.gammaBox.setText(QCoreApplication.translate("mainWindow", u"Custom gamma", None))
-#if QT_CONFIG(tooltip)
-        self.autoLevelBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p>By default, KCC maps the darkest pixel value to pure black (the black point.)</p><p>Extreme black point sets the black point to be the most common dark pixel value.</p><p>Useful when text is black but artwork is gray.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.autoLevelBox.setText(QCoreApplication.translate("mainWindow", u"Extreme Black Point", None))
-#if QT_CONFIG(tooltip)
-        self.interPanelCropBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Disabled<br/></span>Disabled</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Horizontal<br/></span>Crop empty horizontal lines.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Both<br/></span>Crop empty horizontal and vertical lines.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.interPanelCropBox.setText(QCoreApplication.translate("mainWindow", u"Inter-panel crop", None))
-#if QT_CONFIG(tooltip)
-        self.rotateBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Split<br/></span>Double page spreads will be cut into two separate pages.</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Split and rotate<br/></span>Double page spreads will be displayed twice. First split and then rotated. </p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Rotate<br/></span>Double page spreads will be rotated.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.rotateBox.setText(QCoreApplication.translate("mainWindow", u"Spread splitter", None))
-#if QT_CONFIG(tooltip)
-        self.authorEdit.setToolTip(QCoreApplication.translate("mainWindow", u"Default Author is KCC", None))
-#endif // QT_CONFIG(tooltip)
-        self.authorEdit.setPlaceholderText(QCoreApplication.translate("mainWindow", u"Default Author", None))
-#if QT_CONFIG(tooltip)
-        self.croppingBox.setToolTip(QCoreApplication.translate("mainWindow", u"<html><head/><body><p><span style=\" font-weight:600; text-decoration: underline;\">Unchecked - Disabled</span></p><p>Disabled</p><p><span style=\" font-weight:600; text-decoration: underline;\">Indeterminate - Margins<br/></span>Margins</p><p><span style=\" font-weight:600; text-decoration: underline;\">Checked - Margins + page numbers<br/></span>Margins +page numbers</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.croppingBox.setText(QCoreApplication.translate("mainWindow", u"Cropping mode", None))
-#if QT_CONFIG(tooltip)
-        self.pngLegacyBox.setToolTip(QCoreApplication.translate("mainWindow", u"Use a more compatible 8 bit PNG instead of 4 bit.", None))
-#endif // QT_CONFIG(tooltip)
-        self.pngLegacyBox.setText(QCoreApplication.translate("mainWindow", u"PNG Legacy Mode", None))
-#if QT_CONFIG(tooltip)
-        self.forcePngRgbBox.setToolTip(QCoreApplication.translate("mainWindow", u"Force full color images to be saved in lossless PNG format, dramatically increases the filesize.", None))
-#endif // QT_CONFIG(tooltip)
-        self.forcePngRgbBox.setText(QCoreApplication.translate("mainWindow", u"Force PNG RGB", None))
-#if QT_CONFIG(tooltip)
-        self.smartCoverCropBox.setToolTip(QCoreApplication.translate("mainWindow", u"Attempt to crop main cover from wide image.", None))
-#endif // QT_CONFIG(tooltip)
-        self.smartCoverCropBox.setText(QCoreApplication.translate("mainWindow", u"Smart Cover Crop", None))
+        self.webpBox.setText(QCoreApplication.translate("mainWindow", u"WebP (experimental)", None))
         self.gammaLabel.setText(QCoreApplication.translate("mainWindow", u"Gamma: Auto", None))
         self.jpegQualityLabel.setText(QCoreApplication.translate("mainWindow", u"JPEG Quality:", None))
     # retranslateUi

--- a/kindlecomicconverter/KCC_ui.py
+++ b/kindlecomicconverter/KCC_ui.py
@@ -305,6 +305,7 @@ class Ui_mainWindow(object):
 
         self.pngLegacyBox = QCheckBox(self.optionWidget)
         self.pngLegacyBox.setObjectName(u"pngLegacyBox")
+        self.pngLegacyBox.setEnabled(False)
 
         self.gridLayout_2.addWidget(self.pngLegacyBox, 11, 0, 1, 1)
 
@@ -354,6 +355,7 @@ class Ui_mainWindow(object):
 
         self.noQuantizeBox = QCheckBox(self.optionWidget)
         self.noQuantizeBox.setObjectName(u"noQuantizeBox")
+        self.noQuantizeBox.setEnabled(False)
 
         self.gridLayout_2.addWidget(self.noQuantizeBox, 10, 2, 1, 1)
 
@@ -427,6 +429,7 @@ class Ui_mainWindow(object):
 
         self.forcePngRgbBox = QCheckBox(self.optionWidget)
         self.forcePngRgbBox.setObjectName(u"forcePngRgbBox")
+        self.forcePngRgbBox.setEnabled(False)
 
         self.gridLayout_2.addWidget(self.forcePngRgbBox, 11, 2, 1, 1)
 

--- a/kindlecomicconverter/KCC_ui.py
+++ b/kindlecomicconverter/KCC_ui.py
@@ -826,7 +826,7 @@ class Ui_mainWindow(object):
 #if QT_CONFIG(tooltip)
         self.webpBox.setToolTip(QCoreApplication.translate("mainWindow", u"Replace JPG with lossy WebP and PNG with lossless WebP. This includes the JPG Quality.\n"
 "\n"
-"Ignored for Kindle EPUB/MOBI.", None))
+"Ignored for Kindle EPUB/MOBI and all PDF.", None))
 #endif // QT_CONFIG(tooltip)
         self.webpBox.setText(QCoreApplication.translate("mainWindow", u"WebP (experimental)", None))
         self.gammaLabel.setText(QCoreApplication.translate("mainWindow", u"Gamma: Auto", None))

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -353,6 +353,8 @@ def buildOPF(dstdir, title, filelist, originalpath, cover=None):
             mt = 'image/png'
         elif '.gif' == filename[1]:
             mt = 'image/gif'
+        elif '.webp' == filename[1]:
+            mt = 'image/webp'
         else:
             mt = 'image/jpeg'
         f.write("<item id=\"img_" + str(uniqueid) + "\" href=\"" + folder + "/" + path[1] + "\" media-type=\"" +
@@ -1418,6 +1420,8 @@ def makeParser():
                                     help="Create PNG files instead JPEG for black and white images")
     processing_options.add_argument("--force-png-rgb", action="store_true", dest="force_png_rgb", default=False,
                                     help="Force color images to be saved as PNG")
+    processing_options.add_argument("--webp", action="store_true", dest="webp", default=False,
+                                    help="Replace JPG with lossy WEBP and PNG with lossless WEBP")
     processing_options.add_argument("--pnglegacy", action="store_true", dest="pnglegacy", default=False,
                                     help="Use a more compatible 8 bit png instead of 4 bit")
     processing_options.add_argument("--noquantize", action="store_true", dest="noquantize", default=False,

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1541,6 +1541,8 @@ def checkOptions(options):
     options.kindle_azw3 = options.iskindle and ('MOBI' in options.format or 'EPUB' in options.format)
     options.kindle_scribe_azw3 = options.profile.startswith('KS') and options.kindle_azw3
 
+    options.webp_output = options.format != 'PDF' and not options.kindle_azw3 and options.webp
+
     # CBZ files on Kindle DX/DXG support higher resolution
     if options.profile == 'KDX' and options.format == 'CBZ':
         options.profileData = list(image.ProfileData.Profiles[options.profile])

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -408,7 +408,7 @@ class ComicPage:
     def save_with_codec(self, image, targetPath):
         if self.opt.forcepng and (not self.colorOutput or self.opt.force_png_rgb):
             image.info.pop('transparency', None)
-            if not self.opt.kindle_azw3 and self.opt.webp:
+            if self.opt.webp_output:
                 targetPath += '.webp'
                 image.save(targetPath, 'WEBP', lossless=True, quality=self.opt.jpegquality)
             elif self.opt.kindle_azw3:
@@ -418,7 +418,7 @@ class ComicPage:
                 targetPath += '.png'
                 image.save(targetPath, 'PNG', optimize=1)
         else:
-            if not self.opt.kindle_azw3 and self.opt.webp:
+            if self.opt.webp_output:
                 targetPath += '.webp'
                 image.save(targetPath, 'WEBP', quality=self.opt.jpegquality)
             elif self.opt.mozjpeg:

--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -408,15 +408,21 @@ class ComicPage:
     def save_with_codec(self, image, targetPath):
         if self.opt.forcepng and (not self.colorOutput or self.opt.force_png_rgb):
             image.info.pop('transparency', None)
-            if self.opt.iskindle and ('MOBI' in self.opt.format or 'EPUB' in self.opt.format):
+            if not self.opt.kindle_azw3 and self.opt.webp:
+                targetPath += '.webp'
+                image.save(targetPath, 'WEBP', lossless=True, quality=self.opt.jpegquality)
+            elif self.opt.kindle_azw3:
                 targetPath += '.gif'
                 image.save(targetPath, 'GIF', optimize=1, interlace=False)
             else:
                 targetPath += '.png'
                 image.save(targetPath, 'PNG', optimize=1)
         else:
-            targetPath += '.jpg'
-            if self.opt.mozjpeg:
+            if not self.opt.kindle_azw3 and self.opt.webp:
+                targetPath += '.webp'
+                image.save(targetPath, 'WEBP', quality=self.opt.jpegquality)
+            elif self.opt.mozjpeg:
+                targetPath += '.jpg'
                 with io.BytesIO() as output:
                     image.save(output, format="JPEG", optimize=1, quality=self.opt.jpegquality)
                     input_jpeg_bytes = output.getvalue()
@@ -424,6 +430,7 @@ class ComicPage:
                     with open(targetPath, "wb") as output_jpeg_file:
                         output_jpeg_file.write(output_jpeg_bytes)
             else:
+                targetPath += '.jpg'
                 image.save(targetPath, 'JPEG', optimize=1, quality=self.opt.jpegquality)
         return targetPath
 


### PR DESCRIPTION
For a manga file with all default settings:

JPG: 185 MB
mozJPG: 170 MB
PNG: 90 MB
lossy webp: 130 MN
lossless webp: 80 MB

webp doesn't support 16 color 4 bit mode in pillow... so the difference isn't too large @9783e6 

https://github.com/axu2/kcc/releases/tag/v9.6.2-webp

Because Kobo supports webp now