### PR TITLE
File fusion uses OS temp folder if checked

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -393,7 +393,10 @@ class WorkerThread(QThread):
             for job in currentJobs:
                 bookDir.append(job)
             try:
+                fusion_source_parent = str(Path(bookDir[0]).parent)
                 comic2ebook.options = comic2ebook.checkOptions(copy(options))
+                if options.output is None:
+                    options.output = fusion_source_parent
                 currentJobs.clear()
                 currentJobs.append(comic2ebook.makeFusion(bookDir))
                 MW.addMessage.emit('Created fusion at ' + currentJobs[0], 'info', False)
@@ -563,7 +566,8 @@ class WorkerThread(QThread):
                     os.remove(path)
                 elif os.path.isdir(path):
                     rmtree(path, True)
-            comic2ebook.checkPre('LLL-')
+            if not options.tempdir:
+                comic2ebook.checkPre('LLL-')
         GUI.progress.content = ''
         GUI.progress.stop()
         MW.hideProgressBar.emit()

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -76,12 +76,15 @@ def main(argv=None):
         print('No matching files found.')
         return 1
     if options.filefusion:
+        fusion_source_parent = str(Path(sources[0]).parent)
         fusion_path = makeFusion(list(sources))
         sources.clear()
         sources.append(fusion_path)
     for source in sources:
         source = source.rstrip('\\').rstrip('/')
         options = copy(args)
+        if options.filefusion and options.output is None:
+            options.output = fusion_source_parent
         options = checkOptions(options)
         print('Working on ' + source + '...')
         makeBook(source)
@@ -92,7 +95,8 @@ def main(argv=None):
                 os.remove(path)
             elif os.path.isdir(path):
                 rmtree(path, True)
-        checkPre('LLL-')
+        if not options.tempdir:
+            checkPre('LLL-')
     return 0
 
 
@@ -1690,11 +1694,10 @@ def makeFusion(sources: List[str]):
         raise UserWarning('Fusion requires at least 2 sources. Did you forget to uncheck fusion?')
     start = perf_counter()
     first_path = Path(sources[0])
-    
-    if True:
+
+    if options.tempdir:
         fusion_parent = first_path.parent
     else:
-        # LLL is after KCC
         checkPre('LLL-')
         fusion_parent = Path(mkdtemp('', 'LLL-'))
 
@@ -1742,8 +1745,6 @@ def makeBook(source, qtgui=None, job_progress=''):
     else:
         checkTools(source)
     checkPre()
-    if not options.filefusion:
-        checkPre('LLL-')
     print(f"{job_progress}Preparing source images...")
     path = getWorkFolder(source)
     print(f"{job_progress}Checking images...")

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1690,6 +1690,7 @@ def makeFusion(sources: List[str]):
     if options.tempdir:
         fusion_parent = first_path.parent
     else:
+        # LLL is after KCC
         checkPre('LLL-')
         fusion_parent = Path(mkdtemp('', 'LLL-'))
 
@@ -1737,6 +1738,8 @@ def makeBook(source, qtgui=None, job_progress=''):
     else:
         checkTools(source)
     checkPre()
+    if not options.filefusion:
+        checkPre('LLL-')
     print(f"{job_progress}Preparing source images...")
     path = getWorkFolder(source)
     print(f"{job_progress}Checking images...")


### PR DESCRIPTION
Use source folder when output folder is not specified.

* Fixes #1350