### PR TITLE
don't crash if rosetta was uninstalled in macOS 27 Golden Gate

### DIFF
--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1192,7 +1192,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         except OSError as e:
             self.kindleGen = False
             if startup:
-                error = f"kindlegen: {e.strerror} \n Re-install Rosetta/Kindle Previewer/other Intel app? Amazon needs to make Kindle Previewer Apple silicon native.\n "
+                error = f"kindlegen: {e.strerror}\n\n Re-install Rosetta/Kindle Previewer/other Intel app?\n\nAmazon needs to make Kindle Previewer Apple silicon native."
                 self.showDialog(error, 'error')
 
     def __init__(self, kccapp, kccwindow):

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1192,7 +1192,7 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         except OSError as e:
             self.kindleGen = False
             if startup:
-                error = f"kindlegen: {e.strerror}\n\n Re-install Rosetta/Kindle Previewer/other Intel app?\n\nAmazon needs to make Kindle Previewer Apple silicon native."
+                error = f"kindlegen: {e.strerror}\n\n Re-install Rosetta/Kindle Previewer/other Intel app?\n\nPlease email Amazon to make Kindle Previewer Apple silicon native at amazon.com/kindle-help"
                 self.showDialog(error, 'error')
 
     def __init__(self, kccapp, kccwindow):

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1192,9 +1192,8 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
         except OSError as e:
             self.kindleGen = False
             if startup:
-                self.addMessage(e.strerror, 'warning')
-                self.addMessage('Re-install Rosetta/Kindle Previewer/other Intel app?', 'warning')
-                self.addMessage('Amazon needs to make Kindle Previewer Apple silicon native.', 'warning')
+                error = f"kindlegen: {e.strerror} \n Re-install Rosetta/Kindle Previewer/other Intel app? Amazon needs to make Kindle Previewer Apple silicon native.\n "
+                self.showDialog(error, 'error')
 
     def __init__(self, kccapp, kccwindow):
         global APP, MW, GUI

--- a/kindlecomicconverter/KCC_gui.py
+++ b/kindlecomicconverter/KCC_gui.py
@@ -1189,6 +1189,12 @@ class KCCGUI(KCC_ui.Ui_mainWindow):
             self.kindleGen = False
             if startup:
                 self.display_kindlegen_missing()
+        except OSError as e:
+            self.kindleGen = False
+            if startup:
+                self.addMessage(e.strerror, 'warning')
+                self.addMessage('Re-install Rosetta/Kindle Previewer/other Intel app?', 'warning')
+                self.addMessage('Amazon needs to make Kindle Previewer Apple silicon native.', 'warning')
 
     def __init__(self, kccapp, kccwindow):
         global APP, MW, GUI

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1676,7 +1676,7 @@ def checkTools(source):
         except OSError as e:
             print(f"kindlegen: {e.strerror}")
             print('Re-install Rosetta/Kindle Previewer/other Intel app?')
-            print('Amazon needs to make Kindle Previewer Apple silicon native.')
+            print('Please email Amazon to make Kindle Previewer Apple silicon native at amazon.com/kindle-help')
             sys.exit(1)
 
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1673,6 +1673,11 @@ def checkTools(source):
         except (FileNotFoundError, CalledProcessError):
             print('ERROR: KindleGen is missing!')
             sys.exit(1)
+        except OSError as e:
+            print(e.strerror)
+            print('Re-install Rosetta/Kindle Previewer/other Intel app?')
+            print('Amazon needs to make Kindle Previewer Apple silicon native.')
+            sys.exit(1)
 
 
 def checkPre(source='KCC-'):

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1674,7 +1674,7 @@ def checkTools(source):
             print('ERROR: KindleGen is missing!')
             sys.exit(1)
         except OSError as e:
-            print(e.strerror)
+            print(f"kindlegen: {e.strerror}")
             print('Re-install Rosetta/Kindle Previewer/other Intel app?')
             print('Amazon needs to make Kindle Previewer Apple silicon native.')
             sys.exit(1)


### PR DESCRIPTION
- fix #1364 

<img width="239" height="308" alt="image" src="https://github.com/user-attachments/assets/174e2dd0-342b-4af5-a38a-22f7a0110a7c" />



@rayhanmohammedali13-hue

Let me know if you want the error message changed at all. 