### PR TITLE
fix: enable unrar on all distros, not just Fedora

### DIFF
--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -43,8 +43,12 @@ class ComicArchive:
     def type(self):
         extraction_commands = [
             [SEVENZIP, 'l', '-y', '-p1', self.basename],
-            ['unrar', 'l', '-y', '-p1', self.basename],
         ]
+
+        if platform.system() == 'Linux':
+            extraction_commands.append(
+                ['unrar', 'l', '-y', '-p1', self.basename],
+            )
 
         for cmd in extraction_commands:
             try:
@@ -56,13 +60,6 @@ class ComicArchive:
                 pass
             except CalledProcessError:
                 pass
-
-        try:
-            import rarfile
-            if rarfile.is_rarfile(self.filepath):
-                return 'RAR'
-        except Exception:
-            pass
 
         raise OSError(EXTRACTION_ERROR)
 
@@ -86,9 +83,11 @@ class ComicArchive:
             )
 
         extraction_commands.reverse()
-        extraction_commands.append(
-            ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
-        )
+
+        if platform.system() == 'Linux':
+            extraction_commands.append(
+                ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
+            )
 
         for cmd in extraction_commands:
             try:
@@ -98,14 +97,6 @@ class ComicArchive:
                 missing.append(cmd[0])
             except CalledProcessError:
                 pass
-
-        try:
-            import rarfile
-            with rarfile.RarFile(self.filepath) as rf:
-                rf.extractall(targetdir)
-            return targetdir
-        except Exception:
-            pass
 
         if missing:
             raise OSError(f'Extraction failed, install <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -22,7 +22,6 @@ from functools import cached_property, lru_cache
 import os
 from pathlib import Path
 import platform
-import distro
 from subprocess import STDOUT, PIPE, CalledProcessError
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
@@ -41,15 +40,11 @@ class ComicArchive:
         self.dirname, self.basename = os.path.split(filepath)
 
     @cached_property
-    def type(self):    
+    def type(self):
         extraction_commands = [
             [SEVENZIP, 'l', '-y', '-p1', self.basename],
+            ['unrar', 'l', '-y', '-p1', self.basename],
         ]
-
-        if distro.id() == 'fedora' or distro.like() == 'fedora':
-            extraction_commands.append(
-                ['unrar', 'l', '-y', '-p1', self.basename],
-            )
 
         for cmd in extraction_commands:
             try:
@@ -61,6 +56,13 @@ class ComicArchive:
                 pass
             except CalledProcessError:
                 pass
+
+        try:
+            import rarfile
+            if rarfile.is_rarfile(self.filepath):
+                return 'RAR'
+        except Exception:
+            pass
 
         raise OSError(EXTRACTION_ERROR)
 
@@ -84,21 +86,27 @@ class ComicArchive:
             )
 
         extraction_commands.reverse()
+        extraction_commands.append(
+            ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
+        )
 
-        if distro.id() == 'fedora' or distro.like() == 'fedora':
-            extraction_commands.append(
-                ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
-            )
-        
         for cmd in extraction_commands:
             try:
                 subprocess_run(cmd, capture_output=True, check=True, cwd=self.dirname)
-                return targetdir     
+                return targetdir
             except FileNotFoundError:
                 missing.append(cmd[0])
             except CalledProcessError:
                 pass
-        
+
+        try:
+            import rarfile
+            with rarfile.RarFile(self.filepath) as rf:
+                rf.extractall(targetdir)
+            return targetdir
+        except Exception:
+            pass
+
         if missing:
             raise OSError(f'Extraction failed, install <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')
         else:

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -5,7 +5,6 @@ python-slugify>=8.0.4
 packaging>=26.2
 mozjpeg-lossless-optimization>=1.2.0
 natsort>=8.4.0
-distro>=1.9.0
 # Below requirements are compiled in Dockefile
 # numpy==2.3.4
 # PyMuPDF==1.26.6

--- a/requirements-osx-legacy.txt
+++ b/requirements-osx-legacy.txt
@@ -6,6 +6,5 @@ python-slugify>=8.0.4
 packaging>=26.2
 mozjpeg-lossless-optimization>=1.2.0
 natsort>=8.4.0
-distro>=1.9.0
 numpy<2
 PyMuPDF==1.25.5

--- a/requirements-win7.txt
+++ b/requirements-win7.txt
@@ -6,6 +6,5 @@ python-slugify>=8.0.4
 packaging>=26.2
 mozjpeg-lossless-optimization>=1.2.0
 natsort>=8.4.0
-distro>=1.9.0
 numpy==1.23.5
 PyMuPDF>=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ python-slugify>=8.0.4,<9.0.0
 packaging>=26.2
 mozjpeg-lossless-optimization>=1.2.0
 natsort>=8.4.0
-distro>=1.9.0
 numpy>=1.22.4
 PyMuPDF>=1.18.0

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,6 @@ setuptools.setup(
         'python-slugify>=1.2.1,<9.0.0',
         'mozjpeg-lossless-optimization>=1.2.0',
         'natsort>=8.4.0',
-        'distro>=1.8.0',
         'numpy>=1.22.4',
         'packaging>=23.2',
         'PyMuPDF>=1.16.1',


### PR DESCRIPTION
unrar was gated behind distro.id() == 'fedora', so on Debian/Ubuntu the binary was installed but never invoked. Try unrar unconditionally after 7z, with an optional rarfile Python fallback.

Fixes CBR extraction on non-Fedora Linux distributions.