### PR TITLE
fix crash in smart cover crop LTR

### DIFF
--- a/kindlecomicconverter/image.py
+++ b/kindlecomicconverter/image.py
@@ -648,7 +648,7 @@ class Cover:
             if self.options.righttoleft:
                 self.image = self.image.crop((w * .36, 0, w, h))
             else:
-                self.image = self.image.crop((w, 0, .64 * w, h))
+                self.image = self.image.crop((0, 0, .64 * w, h))
 
     def save_to_folder(self, target, tomeid, len_tomes=0):
         try:


### PR DESCRIPTION
found a bug in `crop_main_cover()` in image.py that crashes with `ValueError: Coordinate 'right' is less than 'left'`. happens when smart cover crop is on, reading direction is ltr, and the cover aspect ratio (w/h) is between 1.0 and 1.34, so like a slightly landscape-y cover, not super wide.

the ltr branch for this ratio bucket does `self.image.crop((w, 0, .64 * w, h))`, left=w is always bigger than right=0.64w so pillow throws immediately. pretty sure this was a copy paste mistake from the bracket above it, every other ratio range in this func does right-crop for rtl + left-crop for ltr, this one just had the left bound set to w instead of 0 so it never worked.

changed it to `self.image.crop((0, 0, .64 * w, h))`, crops the left 64% of the img, matches the rtl branch right above it (mirror image basically).

made a test cbz w a 1200x1000 cover, turned on smart cover crop, left rtl off, converted it. crashed b4 the fix, works fine after. tested on macos.