### PR TITLE
Fix macOS app version showing 0.0.0

### DIFF
--- a/kcc-macos.spec
+++ b/kcc-macos.spec
@@ -1,0 +1,61 @@
+# -*- mode: python ; coding: utf-8 -*-
+# macOS GUI build, used by setup.py build_binary
+
+import sys
+
+sys.path.insert(0, SPECPATH)
+from kindlecomicconverter import __version__
+
+
+a = Analysis(
+    ['kcc.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['_cffi_backend'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='Kindle Comic Converter',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=True,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['icons/comic2ebook.icns'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=True,
+    upx=True,
+    upx_exclude=[],
+    name='Kindle Comic Converter',
+)
+app = BUNDLE(
+    coll,
+    name='Kindle Comic Converter.app',
+    icon='icons/comic2ebook.icns',
+    bundle_identifier=None,
+    info_plist={
+        'CFBundleShortVersionString': __version__,
+        'CFBundleVersion': __version__,
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class BuildBinaryCommand(setuptools.Command):
     def run(self):
         VERSION = __version__
         if sys.platform == 'darwin':
-            os.system('pyinstaller --hidden-import=_cffi_backend -y -D -i icons/comic2ebook.icns -n "Kindle Comic Converter" -w -s kcc.py')
+            os.system('pyinstaller -y kcc-macos.spec')
             # TODO /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime dist/Applications/Kindle\ Comic\ Converter.app -v
             min_os = os.getenv('MACOSX_DEPLOYMENT_TARGET', '')
             if min_os.startswith('10.1'):


### PR DESCRIPTION
- Fixes #632
- fix #747 

The macOS build calls pyinstaller directly from the command line in setup.py,
so pyinstaller generates a default Info.plist with CFBundleShortVersionString
set to 0.0.0 and no CFBundleVersion at all. This is still the case in the
10.3.0 release dmg.

Following the suggestion in the issue thread to add an intermediate spec
step, this PR adds kcc-macos.spec and switches the darwin branch of
build_binary to use it. The spec was generated with pyi-makespec using the
exact same flags as the old command. The only addition is the info_plist
section in BUNDLE that reads the version from kindlecomicconverter at build
time, so nothing needs to change in the CI workflows.

Tested locally on an arm64 Mac:
- built the app with the new spec, Info.plist now shows 10.3.0 in both
  CFBundleShortVersionString and CFBundleVersion
- diffed the entire Info.plist against the official 10.3.0 dmg: the version
  fields are the only difference, everything else including CFBundleIdentifier
  is identical
- the built app launches and runs normally

I left bundle_identifier untouched on purpose to keep the change minimal for
the unsigned app.
