### PR TITLE
Bound multiprocessing pools by KCC_WORKERS to cap memory

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -678,7 +678,9 @@ def buildPDF(path, title, job_progress='', cover=None, output_file=None):
 
 def imgDirectoryProcessing(path, job_progress=''):
     global workerPool, workerOutput
-    workerPool = Pool(maxtasksperchild=100)
+    # Bound by KCC_WORKERS like the PDF render pool: each worker holds a full
+    # image in memory, so an unbounded cpu_count() pool can OOM on large books.
+    workerPool = Pool(pdf_render_worker_count(), maxtasksperchild=100)
     workerOutput = []
     options.imgMetadata = {}
     work = []
@@ -2106,6 +2108,9 @@ def makeMOBI(work, qtgui=None):
         threadNumber = 4
     else:
         threadNumber = None
+    # virtual_memory().total reports host/node RAM, not the container limit, so
+    # also cap by KCC_WORKERS to respect a constrained pod's memory budget.
+    threadNumber = min(threadNumber or cpu_count(), pdf_render_worker_count())
     makeMOBIWorkerPool = Pool(threadNumber, maxtasksperchild=10)
     for i in work:
         makeMOBIWorkerPool.apply_async(func=makeMOBIWorker, args=(i, ), callback=makeMOBIWorkerTick)

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -872,6 +872,25 @@ def extract_page(vector):
 
 
 
+def pdf_render_worker_count():
+    """Number of parallel MuPDF render/extract processes.
+
+    Each worker opens the document and holds a full-resolution page pixmap in
+    memory, so peak memory scales with the number of workers. On memory-limited
+    hosts an unbounded cpu_count() pool can exhaust RAM on large or high-DPI
+    PDFs. Honour the KCC_WORKERS environment variable as an upper bound; fall
+    back to the CPU count when it is unset.
+    """
+    workers = cpu_count()
+    env = os.environ.get('KCC_WORKERS')
+    if env:
+        try:
+            workers = min(workers, int(env))
+        except ValueError:
+            pass
+    return max(1, workers)
+
+
 def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_height):
     render = False
     with pymupdf.open(filename) as doc:
@@ -889,7 +908,7 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_
                     render = True
                     break
 
-    cpu = cpu_count()
+    cpu = pdf_render_worker_count()
 
     # make vectors of arguments for the processes
     vectors = [(i, cpu, filename, output_dir, target_width, target_height, options.pdfwidth) for i in range(cpu)]
@@ -897,7 +916,7 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_
 
 
     start = perf_counter()
-    with Pool() as pool:
+    with Pool(cpu) as pool:
         results = pool.map(
             render_page if render else extract_page, vectors
         )


### PR DESCRIPTION
The PDF render/extract pool, the image-processing pool (`imgDirectoryProcessing`, which runs for every conversion) and the MOBI build pool each spawn `cpu_count()` workers. Each worker holds a full-resolution page or image in memory, so peak memory scales with the core count and can exhaust RAM on large or high-DPI files — a real problem on memory-limited/containerised hosts (an 8-core box can need ~8× the per-page memory).

This adds `pdf_render_worker_count()`, which honours a `KCC_WORKERS` environment variable as an upper bound and falls back to `cpu_count()` when unset, and applies it to all three pools. The MOBI pool previously sized itself from `virtual_memory().total`, which reports host RAM rather than a container's memory limit, so it is now also capped.

Default behaviour is unchanged when `KCC_WORKERS` is unset.