### PR TITLE
Skip corrupt pages instead of aborting the whole conversion

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1368,8 +1368,11 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                 path = os.path.join(root, name)
                 pathOrg = orgpath + path.split('OEBPS' + os.path.sep + 'Images')[1]
                 if os.path.getsize(path) == 0:
-                    rmtree(os.path.join(tmppath, '..', '..'), True)
-                    raise RuntimeError('Image file %s is corrupted.' % pathOrg)
+                    # A single corrupt (zero-byte) page should not fail the whole book;
+                    # skip it and continue with the remaining pages.
+                    os.remove(path)
+                    print('WARNING: Skipping corrupt (empty) image %s' % pathOrg)
+                    continue
                 try:
                     img = Image.open(path)
                     imageNumber += 1
@@ -1377,11 +1380,14 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:
                         imageSmaller += 1
                 except Exception as err:
-                    rmtree(os.path.join(tmppath, '..', '..'), True)
                     if 'decoder' in str(err) and 'not available' in str(err):
+                        rmtree(os.path.join(tmppath, '..', '..'), True)
                         raise RuntimeError('Pillow was compiled without JPG and/or PNG decoder.')
-                    else:
-                        raise RuntimeError('Image file %s is corrupted. Error: %s' % (pathOrg, str(err)))
+                    # A single corrupt/unreadable page should not fail the whole book;
+                    # skip it and continue with the remaining pages.
+                    os.remove(path)
+                    print('WARNING: Skipping corrupt image %s (%s)' % (pathOrg, str(err)))
+                    continue
             else:
                 try:
                     if os.path.exists(os.path.join(root, name)):
@@ -1840,7 +1846,7 @@ def makeBook(source, qtgui=None, job_progress=''):
         # Strip the fusion_0001_ sort prefix from makeFusion if present
         chapterNames = {k: sub(r'^fusion_\d{4}_', '', v) for k, v in chapterNames.items()}
     cover = None
-    if not options.webtoon:
+    if not options.webtoon and cover_path:
         cover = image.Cover(cover_path, options)
 
     x, y = image.ProfileData.Profiles[options.profile][1]


### PR DESCRIPTION
A single unreadable or zero-byte page raised `RuntimeError` and failed the entire book, even when every other page was fine. This skips the bad page and carries on, while keeping a genuine environment error (a missing Pillow decoder) fatal so real setup problems still surface. It also guards against a missing cover, so a damaged archive with no usable cover page no longer crashes with a `NoneType` error.

## How to reproduce / test

A comic with one **zero-byte** page and one **unreadable/garbage** page mixed in with valid pages triggers both fatal branches this PR fixes:

**Download:** https://drive.google.com/file/d/1rz38SkzJLcZ3D_laJCdC8XYo5nRg9Ghi/view?usp=drive_link

Save it next to where you run the commands (referred to below as `1399.cbz`). The archive is flat (images at the root) with `page-003-EMPTY.jpg` (0 bytes) and `page-005-GARBAGE.jpg` (non-image bytes) between valid pages.

The easiest way to A/B test any KCC branch without a local setup is [`kcc-run`](https://github.com/NilsLeo/kcc-run), which clones a given `owner/repo:ref` into a throwaway container at runtime:

```bash
export DOCKER_DEFAULT_PLATFORM=linux/amd64   # Apple Silicon; no-op on Intel/AMD
kcc() { docker run --platform linux/amd64 --rm -v "$PWD:/work" -w /work ghcr.io/nilsleo/kcc-run "$@"; }
```

**1. Reproduce the crash on upstream master** (one corrupt page fails the whole book):
```bash
kcc ciromattia/kcc:master -p KV -f EPUB -o out 1399.cbz
```
→ aborts with `RuntimeError: Image file .../page-005-GARBAGE.jpg is corrupted.` at `detectSuboptimalProcessing`; no EPUB produced.

**2. Same file on this branch — skips the bad pages and converts the rest:**
```bash
kcc NilsLeo/kcc:up/image-resilience -p KV -f EPUB -o out 1399.cbz
```
→ logs
```
WARNING: Skipping corrupt image .../page-005-GARBAGE.jpg (cannot identify image file ...)
WARNING: Skipping corrupt (empty) image .../page-003-EMPTY.jpg
```
then writes a valid `out/1399.epub` from the remaining pages.

(Or clone this branch and run `python kcc-c2e.py -p KV -f EPUB -o out 1399.cbz` directly.)
