### PR TITLE
Fall back to a default resolution when the target profile has none

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1372,6 +1372,13 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                     raise RuntimeError('Image file %s is corrupted.' % pathOrg)
                 try:
                     img = Image.open(path)
+                    if 0 in img.size:
+                        # Zero-dimension image (broken/blank page): skip it instead of
+                        # crashing later in resize/thumbnail with ZeroDivisionError.
+                        img.close()
+                        os.remove(path)
+                        print('WARNING: Skipping zero-dimension image %s' % pathOrg)
+                        continue
                     imageNumber += 1
                     # count images smaller than device resolution
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:
@@ -1688,6 +1695,20 @@ def checkOptions(options):
         image.ProfileData.Profiles["Custom"] = newProfile
         options.profile = "Custom"
     options.profileData = image.ProfileData.Profiles[options.profile]
+    # Guard against a zero-sized target resolution. The generic "Other"/"OTHER"
+    # profile is defined as (0, 0) and is meant to be overridden by custom
+    # width/height; when a user selects it without supplying custom dimensions the
+    # (0, 0) target propagates into PIL resize/thumbnail and crashes with a
+    # ZeroDivisionError (surfaced to users as ERR:zero_dimension). Fall back to a
+    # sane default e-reader resolution so the conversion produces valid output.
+    if not options.profileData[1][0] or not options.profileData[1][1]:
+        fallbackRes = (1264, 1680)
+        newProfile = list(options.profileData)
+        newProfile[1] = fallbackRes
+        options.profileData = tuple(newProfile)
+        image.ProfileData.Profiles[options.profile] = options.profileData
+        print('WARNING: profile "%s" has no resolution; falling back to %dx%d'
+              % (options.profile, fallbackRes[0], fallbackRes[1]))
     if not options.jpegquality:
         if options.profile.startswith('KS') or options.profile == 'KCS':
             options.jpegquality = 90

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1372,13 +1372,6 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                     raise RuntimeError('Image file %s is corrupted.' % pathOrg)
                 try:
                     img = Image.open(path)
-                    if 0 in img.size:
-                        # Zero-dimension image (broken/blank page): skip it instead of
-                        # crashing later in resize/thumbnail with ZeroDivisionError.
-                        img.close()
-                        os.remove(path)
-                        print('WARNING: Skipping zero-dimension image %s' % pathOrg)
-                        continue
                     imageNumber += 1
                     # count images smaller than device resolution
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:


### PR DESCRIPTION
Selecting the generic 'Other'/'OTHER' device (profile resolution `(0, 0)`) without supplying custom width/height propagates a `(0, 0)` target into PIL resize/thumbnail, crashing every such conversion with a `ZeroDivisionError`.

This falls back to a sane default e-reader resolution (1264×1680) when the resolved profile has a zero dimension, so the generic profile no longer hard-crashes.

## How to reproduce / test

Any convertible comic reproduces this — the crash is about the **profile**, not the file. You just need an archive that extracts cleanly and is converted with **`-p OTHER`** (no custom `-u`/width/height, so the target resolution stays `(0, 0)`).

**Download:** https://drive.google.com/file/d/1z7SlgQZxPTADimAOhDKxhC41lVmQOMM7/view?usp=drive_link

Save it next to where you run the commands (referred to below as `1400.cbz`). It is a plain flat CBZ of valid pages; the only thing that matters is the `-p OTHER` profile.

The easiest way to A/B test any KCC branch without a local setup is [`kcc-run`](https://github.com/NilsLeo/kcc-run), which clones a given `owner/repo:ref` into a throwaway container at runtime:

```bash
export DOCKER_DEFAULT_PLATFORM=linux/amd64   # Apple Silicon; no-op on Intel/AMD
kcc() { docker run --platform linux/amd64 --rm -v "$PWD:/work" -w /work ghcr.io/nilsleo/kcc-run "$@"; }
```

**1. Reproduce the crash on upstream master** (`-p OTHER`, no custom size):
```bash
kcc ciromattia/kcc:master -p OTHER -f EPUB -o out 1400.cbz
```
→ aborts with `ZeroDivisionError: division by zero` in `PIL/Image.py` `thumbnail` (target resolution `(0, 0)`).

**2. Same file on this branch — falls back and converts:**
```bash
kcc NilsLeo/kcc:up/default-resolution-fallback -p OTHER -f EPUB -o out 1400.cbz
```
→ logs `WARNING: profile "OTHER" has no resolution; falling back to 1264x1680`, then writes a valid `out/1400.epub`.

**Control** — a real profile already works on master, confirming it is the profile and not the file:
```bash
kcc ciromattia/kcc:master -p KV -f EPUB -o out 1400.cbz
```

(Or clone this branch and run `python kcc-c2e.py -p OTHER -f EPUB -o out 1400.cbz` directly.)
