### PR TITLE
fix flattening single-subfolder archive of images

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -984,6 +984,7 @@ def getWorkFolder(afile, workdir=None):
                     else:
                         workdir2 = mkdtemp('', 'KCC-')
                     fullPath2 = os.path.join(workdir2, 'OEBPS', 'Images')
+                    os.makedirs(fullPath2, exist_ok=True)
                     for file in os.listdir(os.path.join(fullPath, tdir[0])):
                         move(os.path.join(fullPath, tdir[0], file), fullPath2)
                     rmtree(workdir, True)


### PR DESCRIPTION
## Problem

When an extracted comic archive contains **exactly one top-level folder** (a very common packaging shape, e.g. `MyComic.cbz` → `MyComic/` → `*.jpg`), `getWorkFolder` flattens it by moving every image up into a fresh `workdir2/OEBPS/Images`. That destination directory is built as a path but **never created**, so `shutil.move()` falls through to `copy2()` → `open(dst, 'wb')` and the whole conversion aborts:

```
File ".../comic2ebook.py", line 988, in getWorkFolder
    move(os.path.join(fullPath, tdir[0], file), fullPath2)
...
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/KCC-xxxx/OEBPS/Images'
```

Every other page is fine — the book fails purely because the target directory wasn't made first.

## Fix

Create the destination directory before moving files into it:

```python
fullPath2 = os.path.join(workdir2, 'OEBPS', 'Images')
os.makedirs(fullPath2, exist_ok=True)   # <-- added
for file in os.listdir(os.path.join(fullPath, tdir[0])):
    move(os.path.join(fullPath, tdir[0], file), fullPath2)
```

One line, no behavioural change for archives that already extract successfully.

## How to reproduce / test

A real comic that triggers this (single wrapping folder inside the `.cbz`):

**Download:** https://drive.google.com/file/d/1pb3gJ-UItcC7SoHKsGXgcH5DjADgvGDr/view?usp=drive_link

Save it next to where you run the commands (referred to below as `book.cbz`). You can verify the triggering shape with `unzip -l book.cbz` — everything sits under a single top-level folder.

The easiest way to A/B test any KCC branch without a local setup is [`kcc-run`](https://github.com/NilsLeo/kcc-run), which clones a given `owner/repo:ref` into a throwaway container at runtime:

```bash
export DOCKER_DEFAULT_PLATFORM=linux/amd64   # Apple Silicon; no-op on Intel/AMD
kcc() { docker run --platform linux/amd64 --rm -v "$PWD:/work" -w /work ghcr.io/nilsleo/kcc-run "$@"; }
```

**1. Reproduce the crash on upstream master:**
```bash
kcc ciromattia/kcc:master -p KV -f EPUB -o out book.cbz
```
→ aborts with `FileNotFoundError: .../OEBPS/Images` at `getWorkFolder`.

**2. Same file on this branch — converts cleanly:**
```bash
kcc NilsLeo/kcc:fix/getworkfolder-single-subdir -p KV -f EPUB -o out book.cbz
```
→ proceeds through `Preparing → Checking → Processing images...` and writes an EPUB to `out/`.

(Or clone this branch and run `python kcc-c2e.py -p KV -f EPUB -o out book.cbz` directly.)
