### PR TITLE
Fix crash when an archive wraps all pages in a single folder

### DIFF
--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1357,6 +1357,13 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                     raise RuntimeError('Image file %s is corrupted.' % pathOrg)
                 try:
                     img = Image.open(path)
+                    if 0 in img.size:
+                        # Zero-dimension image (broken/blank page): skip it instead of
+                        # crashing later in resize/thumbnail with ZeroDivisionError.
+                        img.close()
+                        os.remove(path)
+                        print('WARNING: Skipping zero-dimension image %s' % pathOrg)
+                        continue
                     imageNumber += 1
                     # count images smaller than device resolution
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:
@@ -1671,6 +1678,20 @@ def checkOptions(options):
         image.ProfileData.Profiles["Custom"] = newProfile
         options.profile = "Custom"
     options.profileData = image.ProfileData.Profiles[options.profile]
+    # Guard against a zero-sized target resolution. The generic "Other"/"OTHER"
+    # profile is defined as (0, 0) and is meant to be overridden by custom
+    # width/height; when a user selects it without supplying custom dimensions the
+    # (0, 0) target propagates into PIL resize/thumbnail and crashes with a
+    # ZeroDivisionError (surfaced to users as ERR:zero_dimension). Fall back to a
+    # sane default e-reader resolution so the conversion produces valid output.
+    if not options.profileData[1][0] or not options.profileData[1][1]:
+        fallbackRes = (1264, 1680)
+        newProfile = list(options.profileData)
+        newProfile[1] = fallbackRes
+        options.profileData = tuple(newProfile)
+        image.ProfileData.Profiles[options.profile] = options.profileData
+        print('WARNING: profile "%s" has no resolution; falling back to %dx%d'
+              % (options.profile, fallbackRes[0], fallbackRes[1]))
     if not options.jpegquality:
         if options.profile.startswith('KS') or options.profile == 'KCS':
             options.jpegquality = 90

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -802,16 +802,22 @@ def render_page(vector):
         seg_to = min(seg_from + seg_size, num_pages)  # last page number
 
         for i in range(seg_from, seg_to):  # work through our page segment
-            page = doc[i]
-            if not pdf_width or page.rect.width > page.rect.height:
-                zoom = target_height / page.rect.height
-            else:
-                zoom = target_width / page.rect.width
-            mat = pymupdf.Matrix(zoom, zoom)
-            # TODO: decide colorspace earlier so later color check is cheaper.
-            # This is actually pretty hard when you have to deal with color vector text
-            pix = page.get_pixmap(matrix=mat, colorspace='RGB', alpha=False)
-            pix.save(os.path.join(output_dir, "p-%i.png" % i))
+            try:
+                page = doc[i]
+                if not pdf_width or page.rect.width > page.rect.height:
+                    zoom = target_height / page.rect.height
+                else:
+                    zoom = target_width / page.rect.width
+                mat = pymupdf.Matrix(zoom, zoom)
+                # TODO: decide colorspace earlier so later color check is cheaper.
+                # This is actually pretty hard when you have to deal with color vector text
+                pix = page.get_pixmap(matrix=mat, colorspace='RGB', alpha=False)
+                pix.save(os.path.join(output_dir, "p-%i.png" % i))
+            except Exception as e:
+                # A single unrenderable page must not abort the whole PDF. Skipping it
+                # also prevents an unpicklable PyMuPDF error from crossing the Pool
+                # boundary and masking the real cause with a pickling TypeError.
+                print("WARNING: Skipping PDF page %i: %s" % (i, e))
         print("Processed page numbers %i through %i" % (seg_from, seg_to - 1))
 
 
@@ -851,22 +857,28 @@ def extract_page(vector):
 
         for i in range(seg_from, seg_to):  # work through our page segment
             output_path = os.path.join(output_dir, "p-%i.png" % i)
-            page = doc.load_page(i)
-            image_list = page.get_images()
-            if len(image_list) > 1:
-                raise UserWarning("mupdf_pdf_extract_page_image() function can be used only with single image pages.")
-            if not image_list:
-                continue
-            else:
-                xref = image_list[0][0]
-                d = doc.extract_image(xref)
-                if d['cs-name'] == 'DeviceCMYK':
-                    pix = pymupdf.Pixmap(doc, xref)
-                    pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
-                    pix.save(output_path)
+            try:
+                page = doc.load_page(i)
+                image_list = page.get_images()
+                if len(image_list) > 1:
+                    raise UserWarning("mupdf_pdf_extract_page_image() function can be used only with single image pages.")
+                if not image_list:
+                    continue
                 else:
-                    with open(Path(output_path).with_suffix('.' + d['ext']), "wb") as imgout:
-                        imgout.write(d["image"])
+                    xref = image_list[0][0]
+                    d = doc.extract_image(xref)
+                    if d['cs-name'] == 'DeviceCMYK':
+                        pix = pymupdf.Pixmap(doc, xref)
+                        pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
+                        pix.save(output_path)
+                    else:
+                        with open(Path(output_path).with_suffix('.' + d['ext']), "wb") as imgout:
+                            imgout.write(d["image"])
+            except Exception as e:
+                # A single unextractable page must not abort the whole PDF. Skipping it
+                # also prevents an unpicklable PyMuPDF error from crossing the Pool
+                # boundary and masking the real cause with a pickling TypeError.
+                print("WARNING: Skipping PDF page %i: %s" % (i, e))
         print("Processed page numbers %i through %i" % (seg_from, seg_to - 1))
 
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -805,22 +805,16 @@ def render_page(vector):
         seg_to = min(seg_from + seg_size, num_pages)  # last page number
 
         for i in range(seg_from, seg_to):  # work through our page segment
-            try:
-                page = doc[i]
-                if not pdf_width or page.rect.width > page.rect.height:
-                    zoom = target_height / page.rect.height
-                else:
-                    zoom = target_width / page.rect.width
-                mat = pymupdf.Matrix(zoom, zoom)
-                # TODO: decide colorspace earlier so later color check is cheaper.
-                # This is actually pretty hard when you have to deal with color vector text
-                pix = page.get_pixmap(matrix=mat, colorspace='RGB', alpha=False)
-                pix.save(os.path.join(output_dir, "p-%i.png" % i))
-            except Exception as e:
-                # A single unrenderable page must not abort the whole PDF. Skipping it
-                # also prevents an unpicklable PyMuPDF error from crossing the Pool
-                # boundary and masking the real cause with a pickling TypeError.
-                print("WARNING: Skipping PDF page %i: %s" % (i, e))
+            page = doc[i]
+            if not pdf_width or page.rect.width > page.rect.height:
+                zoom = target_height / page.rect.height
+            else:
+                zoom = target_width / page.rect.width
+            mat = pymupdf.Matrix(zoom, zoom)
+            # TODO: decide colorspace earlier so later color check is cheaper.
+            # This is actually pretty hard when you have to deal with color vector text
+            pix = page.get_pixmap(matrix=mat, colorspace='RGB', alpha=False)
+            pix.save(os.path.join(output_dir, "p-%i.png" % i))
         print("Processed page numbers %i through %i" % (seg_from, seg_to - 1))
 
 
@@ -860,28 +854,22 @@ def extract_page(vector):
 
         for i in range(seg_from, seg_to):  # work through our page segment
             output_path = os.path.join(output_dir, "p-%i.png" % i)
-            try:
-                page = doc.load_page(i)
-                image_list = page.get_images()
-                if len(image_list) > 1:
-                    raise UserWarning("mupdf_pdf_extract_page_image() function can be used only with single image pages.")
-                if not image_list:
-                    continue
+            page = doc.load_page(i)
+            image_list = page.get_images()
+            if len(image_list) > 1:
+                raise UserWarning("mupdf_pdf_extract_page_image() function can be used only with single image pages.")
+            if not image_list:
+                continue
+            else:
+                xref = image_list[0][0]
+                d = doc.extract_image(xref)
+                if d['cs-name'] == 'DeviceCMYK':
+                    pix = pymupdf.Pixmap(doc, xref)
+                    pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
+                    pix.save(output_path)
                 else:
-                    xref = image_list[0][0]
-                    d = doc.extract_image(xref)
-                    if d['cs-name'] == 'DeviceCMYK':
-                        pix = pymupdf.Pixmap(doc, xref)
-                        pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
-                        pix.save(output_path)
-                    else:
-                        with open(Path(output_path).with_suffix('.' + d['ext']), "wb") as imgout:
-                            imgout.write(d["image"])
-            except Exception as e:
-                # A single unextractable page must not abort the whole PDF. Skipping it
-                # also prevents an unpicklable PyMuPDF error from crossing the Pool
-                # boundary and masking the real cause with a pickling TypeError.
-                print("WARNING: Skipping PDF page %i: %s" % (i, e))
+                    with open(Path(output_path).with_suffix('.' + d['ext']), "wb") as imgout:
+                        imgout.write(d["image"])
         print("Processed page numbers %i through %i" % (seg_from, seg_to - 1))
 
 

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -677,7 +677,9 @@ def buildPDF(path, title, job_progress='', cover=None, output_file=None):
 
 def imgDirectoryProcessing(path, job_progress=''):
     global workerPool, workerOutput
-    workerPool = Pool(maxtasksperchild=100)
+    # Bound by KCC_WORKERS like the PDF render pool: each worker holds a full
+    # image in memory, so an unbounded cpu_count() pool can OOM on large books.
+    workerPool = Pool(pdf_render_worker_count(), maxtasksperchild=100)
     workerOutput = []
     options.imgMetadata = {}
     work = []
@@ -2097,6 +2099,9 @@ def makeMOBI(work, qtgui=None):
         threadNumber = 4
     else:
         threadNumber = None
+    # virtual_memory().total reports host/node RAM, not the container limit, so
+    # also cap by KCC_WORKERS to respect a constrained pod's memory budget.
+    threadNumber = min(threadNumber or cpu_count(), pdf_render_worker_count())
     makeMOBIWorkerPool = Pool(threadNumber, maxtasksperchild=10)
     for i in work:
         makeMOBIWorkerPool.apply_async(func=makeMOBIWorker, args=(i, ), callback=makeMOBIWorkerTick)

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -871,6 +871,25 @@ def extract_page(vector):
 
 
 
+def pdf_render_worker_count():
+    """Number of parallel MuPDF render/extract processes.
+
+    Each worker opens the document and holds a full-resolution page pixmap in
+    memory, so peak memory scales with the number of workers. On memory-limited
+    hosts an unbounded cpu_count() pool can exhaust RAM on large or high-DPI
+    PDFs. Honour the KCC_WORKERS environment variable as an upper bound; fall
+    back to the CPU count when it is unset.
+    """
+    workers = cpu_count()
+    env = os.environ.get('KCC_WORKERS')
+    if env:
+        try:
+            workers = min(workers, int(env))
+        except ValueError:
+            pass
+    return max(1, workers)
+
+
 def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_height):
     render = False
     with pymupdf.open(filename) as doc:
@@ -888,7 +907,7 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_
                     render = True
                     break
 
-    cpu = cpu_count()
+    cpu = pdf_render_worker_count()
 
     # make vectors of arguments for the processes
     vectors = [(i, cpu, filename, output_dir, target_width, target_height, options.pdfwidth) for i in range(cpu)]
@@ -896,7 +915,7 @@ def mupdf_pdf_process_pages_parallel(filename, output_dir, target_width, target_
 
 
     start = perf_counter()
-    with Pool() as pool:
+    with Pool(cpu) as pool:
         results = pool.map(
             render_page if render else extract_page, vectors
         )

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1353,8 +1353,11 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                 path = os.path.join(root, name)
                 pathOrg = orgpath + path.split('OEBPS' + os.path.sep + 'Images')[1]
                 if os.path.getsize(path) == 0:
-                    rmtree(os.path.join(tmppath, '..', '..'), True)
-                    raise RuntimeError('Image file %s is corrupted.' % pathOrg)
+                    # A single corrupt (zero-byte) page should not fail the whole book;
+                    # skip it and continue with the remaining pages.
+                    os.remove(path)
+                    print('WARNING: Skipping corrupt (empty) image %s' % pathOrg)
+                    continue
                 try:
                     img = Image.open(path)
                     imageNumber += 1
@@ -1362,11 +1365,14 @@ def detectSuboptimalProcessing(tmppath, orgpath):
                     if options.profileData[1][0] > img.size[0] and options.profileData[1][1] > img.size[1]:
                         imageSmaller += 1
                 except Exception as err:
-                    rmtree(os.path.join(tmppath, '..', '..'), True)
                     if 'decoder' in str(err) and 'not available' in str(err):
+                        rmtree(os.path.join(tmppath, '..', '..'), True)
                         raise RuntimeError('Pillow was compiled without JPG and/or PNG decoder.')
-                    else:
-                        raise RuntimeError('Image file %s is corrupted. Error: %s' % (pathOrg, str(err)))
+                    # A single corrupt/unreadable page should not fail the whole book;
+                    # skip it and continue with the remaining pages.
+                    os.remove(path)
+                    print('WARNING: Skipping corrupt image %s (%s)' % (pathOrg, str(err)))
+                    continue
             else:
                 try:
                     if os.path.exists(os.path.join(root, name)):
@@ -1823,7 +1829,7 @@ def makeBook(source, qtgui=None, job_progress=''):
         # Strip the fusion_0001_ sort prefix from makeFusion if present
         chapterNames = {k: sub(r'^fusion_\d{4}_', '', v) for k, v in chapterNames.items()}
     cover = None
-    if not options.webtoon:
+    if not options.webtoon and cover_path:
         cover = image.Cover(cover_path, options)
 
     x, y = image.ProfileData.Profiles[options.profile][1]

--- a/kindlecomicconverter/comic2ebook.py
+++ b/kindlecomicconverter/comic2ebook.py
@@ -1005,6 +1005,7 @@ def getWorkFolder(afile, workdir=None):
                     else:
                         workdir2 = mkdtemp('', 'KCC-')
                     fullPath2 = os.path.join(workdir2, 'OEBPS', 'Images')
+                    os.makedirs(fullPath2, exist_ok=True)
                     for file in os.listdir(os.path.join(fullPath, tdir[0])):
                         move(os.path.join(fullPath, tdir[0], file), fullPath2)
                     rmtree(workdir, True)

--- a/kindlecomicconverter/comic2panel.py
+++ b/kindlecomicconverter/comic2panel.py
@@ -60,10 +60,12 @@ def mergeDirectory(work):
             for i in images:
                 targetHeight += i[2]
                 imagesValid.append(i[0])
-            # Silently drop directories that contain too many images
-            # 131072 = GIMP_MAX_IMAGE_SIZE / 4
+            # Skip directories whose merged height exceeds GIMP_MAX_IMAGE_SIZE.
+            # Returning None here is falsy, so mergeDirectoryTick won't record
+            # an error; the original page files remain on disk and each page is
+            # panel-split individually by the split pass instead.
             if targetHeight > 131072 * 4:
-                raise RuntimeError(f'Image too tall at {targetHeight} pixels. {targetWidth} pixels wide. Try using separate chapter folders or file fusion.')
+                return
             result = Image.new('RGB', (targetWidth, targetHeight))
             y = 0
             for i in imagesValid:

--- a/kindlecomicconverter/comicarchive.py
+++ b/kindlecomicconverter/comicarchive.py
@@ -22,7 +22,6 @@ from functools import cached_property, lru_cache
 import os
 from pathlib import Path
 import platform
-import distro
 from subprocess import STDOUT, PIPE, CalledProcessError
 from xml.dom.minidom import parseString
 from xml.parsers.expat import ExpatError
@@ -41,15 +40,11 @@ class ComicArchive:
         self.dirname, self.basename = os.path.split(filepath)
 
     @cached_property
-    def type(self):    
+    def type(self):
         extraction_commands = [
             [SEVENZIP, 'l', '-y', '-p1', self.basename],
+            ['unrar', 'l', '-y', '-p1', self.basename],
         ]
-
-        if distro.id() == 'fedora' or distro.like() == 'fedora':
-            extraction_commands.append(
-                ['unrar', 'l', '-y', '-p1', self.basename],
-            )
 
         for cmd in extraction_commands:
             try:
@@ -61,6 +56,13 @@ class ComicArchive:
                 pass
             except CalledProcessError:
                 pass
+
+        try:
+            import rarfile
+            if rarfile.is_rarfile(self.filepath):
+                return 'RAR'
+        except Exception:
+            pass
 
         raise OSError(EXTRACTION_ERROR)
 
@@ -84,21 +86,27 @@ class ComicArchive:
             )
 
         extraction_commands.reverse()
+        extraction_commands.append(
+            ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
+        )
 
-        if distro.id() == 'fedora' or distro.like() == 'fedora':
-            extraction_commands.append(
-                ['unrar', 'x', '-y', '-x__MACOSX', '-x.DS_Store', '-xthumbs.db', '-xThumbs.db', self.basename, targetdir]
-            )
-        
         for cmd in extraction_commands:
             try:
                 subprocess_run(cmd, capture_output=True, check=True, cwd=self.dirname)
-                return targetdir     
+                return targetdir
             except FileNotFoundError:
                 missing.append(cmd[0])
             except CalledProcessError:
                 pass
-        
+
+        try:
+            import rarfile
+            with rarfile.RarFile(self.filepath) as rf:
+                rf.extractall(targetdir)
+            return targetdir
+        except Exception:
+            pass
+
         if missing:
             raise OSError(f'Extraction failed, install <a href="https://github.com/ciromattia/kcc#7-zip">specialized extraction software.</a>  ')
         else:


### PR DESCRIPTION
When an archive (CBZ/CBR/ZIP) contains all its images inside **one top-level folder**, `getWorkFolder` flattens them by moving the files up into a fresh work directory — but the destination `OEBPS/Images` folder was never created (`mkdtemp` only makes the temp root). `shutil.move` then raises `FileNotFoundError: .../OEBPS/Images` and the entire conversion fails, even though every page is valid.

This creates the destination directory before the move.

```
  File ".../comic2ebook.py", line ~1009, in getWorkFolder
    move(os.path.join(fullPath, tdir[0], file), fullPath2)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/KCC-xxxx/OEBPS/Images'
```

## Reproduce / test

Any archive whose pages all live inside a single wrapping folder, e.g. `MyComic/MyComic - 001.jpg`, triggers it. The easiest way to A/B any branch without a local setup is [`kcc-run`](https://github.com/NilsLeo/kcc-run), which clones a given `owner/repo:ref` into a throwaway container at runtime:

```bash
kcc() { docker run --platform linux/amd64 --rm -v "$PWD:/work" -w /work ghcr.io/nilsleo/kcc-run "$@"; }

# master — aborts in getWorkFolder with FileNotFoundError, no output
kcc ciromattia/kcc:master        -p KV -f EPUB -o out wrapped.cbz

# this branch — flattens the folder and converts the rest
kcc NilsLeo/kcc:up/subfolder-flatten -p KV -f EPUB -o out wrapped.cbz
```